### PR TITLE
feat(package managers): add homebrew_cask release in goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,6 +32,29 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
 
+homebrew_casks:
+  - name: wifitui
+    directory: Casks/w
+    repository:
+      owner: shazow
+      name: homebrew-cask
+      branch: "{{.ProjectName}}-{{.Version}}"
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: true
+        base:
+          owner: Homebrew
+          name: homebrew-cask
+          branch: main
+
+    homepage: "https://github.com/shazow/wifitui"
+    description: "Connect to known WiFi networks and store profiles, all from the terminal"
+    license:  "MIT"
+
+    binaries:
+      - wifitui
+
 changelog:
   sort: asc
 


### PR DESCRIPTION
Regarding #48 

Took a jab at making this automatically release a Cask to [Homebrew](https://brew.sh/) on tagged releases.

It makes PRs to the [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask) repo.

Example can be seen here: https://github.com/Homebrew/homebrew-cask/pull/240972

In order to set this up, the [GoReleaser homebrew_casks](https://goreleaser.com/customization/homebrew_casks/) require you to have a fork of Homebrew/homebrew-cask, like I have here: https://github.com/tonur/homebrew-cask

It also requires a token, which I made as a secret called "HOMEBREW_TAP_TOKEN", with the following permissions in order to sync your existing fork and make a PR:
<img width="1465" height="876" alt="image" src="https://github.com/user-attachments/assets/8d67a18a-78d2-46d8-a8e6-635f3ff747fc" />

Let me know if you are not interested in this, if so, I will perhaps try to make my own way of syncing releases to Homebrew.