### PR TITLE
Adds Homebrew installation steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ yay -S wifitui-bin
 sudo pacman-key --recv-keys 065D66BF7EFEB02BCDC75FF6227578D96B6A5E4C
 sudo pacman-key --lsign-key 065D66BF7EFEB02BCDC75FF6227578D96B6A5E4C
 sudo pacman -U "${LATEST_RELEASE}.pkg.tar.zst"
+
+# Homebrew for macOS and Linux
+brew install wifitui
 ```
 
 


### PR DESCRIPTION
wifitui was added to Homebrew in https://github.com/Homebrew/homebrew-core/pull/258920

See its formula page: https://formulae.brew.sh/formula/wifitui

See also https://github.com/shazow/wifitui/pull/109