### PR TITLE
fix(darwin): replace deprecated airport command with system_profiler

### DIFF
--- a/wifi/darwin/darwin_logic.go
+++ b/wifi/darwin/darwin_logic.go
@@ -1,11 +1,146 @@
 package darwin
 
 import (
+	"bufio"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/shazow/wifitui/wifi"
 )
+
+type scannedNetwork struct {
+	ssid     string
+	security wifi.SecurityType
+	rssi     int
+	isActive bool
+}
+
+// parseSystemProfilerOutput parses the output of `system_profiler SPAirPortDataType`
+// to extract visible Wi-Fi networks with their signal strength and security.
+func parseSystemProfilerOutput(output string) []scannedNetwork {
+	var networks []scannedNetwork
+	processedSSIDs := make(map[string]bool)
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	inCurrentNetwork := false
+	inOtherNetworks := false
+	var currentNetwork *scannedNetwork
+
+	signalRe := regexp.MustCompile(`Signal / Noise:\s*(-?\d+)\s*dBm`)
+	securityRe := regexp.MustCompile(`Security:\s*(.+)`)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Detect section headers
+		if strings.Contains(line, "Current Network Information:") {
+			inCurrentNetwork = true
+			inOtherNetworks = false
+			continue
+		}
+		if strings.Contains(line, "Other Local Wi-Fi Networks:") {
+			inCurrentNetwork = false
+			inOtherNetworks = true
+			continue
+		}
+
+		// Stop parsing if we hit another interface (like awdl0)
+		if strings.HasPrefix(strings.TrimSpace(line), "awdl") {
+			break
+		}
+
+		if !inCurrentNetwork && !inOtherNetworks {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		// Network name detection: lines that end with ":" and have specific indentation
+		// In system_profiler output, network names are at a specific indent level
+		leadingSpaces := len(line) - len(strings.TrimLeft(line, " "))
+
+		// Network names are at 12-space indent (under Current/Other sections)
+		if leadingSpaces == 12 && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, ": ") {
+			// Save previous network if exists
+			if currentNetwork != nil && currentNetwork.ssid != "" {
+				if !processedSSIDs[currentNetwork.ssid] {
+					networks = append(networks, *currentNetwork)
+					processedSSIDs[currentNetwork.ssid] = true
+				} else if currentNetwork.rssi != 0 {
+					// Update existing entry if this one has signal strength
+					for i := range networks {
+						if networks[i].ssid == currentNetwork.ssid && networks[i].rssi == 0 {
+							networks[i].rssi = currentNetwork.rssi
+							break
+						}
+					}
+				}
+			}
+
+			ssid := strings.TrimSuffix(trimmed, ":")
+			currentNetwork = &scannedNetwork{
+				ssid:     ssid,
+				isActive: inCurrentNetwork,
+				rssi:     0,
+				security: wifi.SecurityOpen,
+			}
+			continue
+		}
+
+		// Parse properties of current network
+		if currentNetwork != nil {
+			if matches := signalRe.FindStringSubmatch(line); len(matches) > 1 {
+				rssi, _ := strconv.Atoi(matches[1])
+				currentNetwork.rssi = rssi
+			}
+			if matches := securityRe.FindStringSubmatch(line); len(matches) > 1 {
+				secStr := strings.TrimSpace(matches[1])
+				currentNetwork.security = parseSecurityType(secStr)
+			}
+		}
+	}
+
+	// Don't forget the last network
+	if currentNetwork != nil && currentNetwork.ssid != "" {
+		if !processedSSIDs[currentNetwork.ssid] {
+			networks = append(networks, *currentNetwork)
+		} else if currentNetwork.rssi != 0 {
+			for i := range networks {
+				if networks[i].ssid == currentNetwork.ssid && networks[i].rssi == 0 {
+					networks[i].rssi = currentNetwork.rssi
+					break
+				}
+			}
+		}
+	}
+
+	return networks
+}
+
+func parseSecurityType(s string) wifi.SecurityType {
+	s = strings.ToLower(s)
+	if strings.Contains(s, "wpa3") || strings.Contains(s, "wpa2") || strings.Contains(s, "wpa") {
+		return wifi.SecurityWPA
+	}
+	if strings.Contains(s, "wep") {
+		return wifi.SecurityWEP
+	}
+	return wifi.SecurityOpen
+}
+
+func rssiToStrength(rssi int) uint8 {
+	if rssi >= 0 || rssi <= -100 {
+		return 0
+	}
+	strength := uint8(2 * (rssi + 100))
+	if strength > 100 {
+		strength = 100
+	}
+	return strength
+}
 
 // findWifiDevice parses the output of `networksetup -listallhardwareports` to find the Wi-Fi device.
 func findWifiDevice(output string) (string, error) {

--- a/wifi/darwin/darwin_test.go
+++ b/wifi/darwin/darwin_test.go
@@ -1,6 +1,10 @@
 package darwin
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/shazow/wifitui/wifi"
+)
 
 func TestFindWifiDevice(t *testing.T) {
 	mockedOutput := `Hardware Port: Wi-Fi
@@ -21,5 +25,117 @@ Ethernet Address: a1:b2:c3:d4:e5:f8`
 	}
 	if device != "en0" {
 		t.Fatalf(`findWifiDevice returned "%s", want "en0"`, device)
+	}
+}
+
+func TestParseSystemProfilerOutput(t *testing.T) {
+	mockedOutput := `Wi-Fi:
+
+      Software Versions:
+          CoreWLAN: 16.0 (1657)
+      Interfaces:
+        en0:
+          Card Type: Wi-Fi
+          Status: Connected
+          Current Network Information:
+            MyHomeNetwork:
+              PHY Mode: 802.11ac
+              Channel: 36 (5GHz, 80MHz)
+              Network Type: Infrastructure
+              Security: WPA2 Personal
+              Signal / Noise: -55 dBm / -95 dBm
+              Transmit Rate: 866
+          Other Local Wi-Fi Networks:
+            NeighborWiFi:
+              PHY Mode: 802.11n
+              Channel: 6 (2GHz, 20MHz)
+              Network Type: Infrastructure
+              Security: WPA2 Personal
+              Signal / Noise: -75 dBm / -90 dBm
+            OpenCafe:
+              PHY Mode: 802.11g
+              Channel: 11 (2GHz, 20MHz)
+              Network Type: Infrastructure
+              Security: Open
+        awdl0:
+          MAC Address: 00:11:22:33:44:55`
+
+	networks := parseSystemProfilerOutput(mockedOutput)
+
+	if len(networks) != 3 {
+		t.Fatalf("expected 3 networks, got %d", len(networks))
+	}
+
+	// Check active network
+	found := false
+	for _, n := range networks {
+		if n.ssid == "MyHomeNetwork" {
+			found = true
+			if !n.isActive {
+				t.Error("MyHomeNetwork should be marked as active")
+			}
+			if n.rssi != -55 {
+				t.Errorf("MyHomeNetwork rssi should be -55, got %d", n.rssi)
+			}
+			if n.security != wifi.SecurityWPA {
+				t.Errorf("MyHomeNetwork security should be WPA, got %v", n.security)
+			}
+		}
+	}
+	if !found {
+		t.Error("MyHomeNetwork not found in parsed networks")
+	}
+
+	// Check neighbor network
+	found = false
+	for _, n := range networks {
+		if n.ssid == "NeighborWiFi" {
+			found = true
+			if n.isActive {
+				t.Error("NeighborWiFi should not be marked as active")
+			}
+			if n.rssi != -75 {
+				t.Errorf("NeighborWiFi rssi should be -75, got %d", n.rssi)
+			}
+		}
+	}
+	if !found {
+		t.Error("NeighborWiFi not found in parsed networks")
+	}
+
+	// Check open network
+	found = false
+	for _, n := range networks {
+		if n.ssid == "OpenCafe" {
+			found = true
+			if n.security != wifi.SecurityOpen {
+				t.Errorf("OpenCafe security should be Open, got %v", n.security)
+			}
+		}
+	}
+	if !found {
+		t.Error("OpenCafe not found in parsed networks")
+	}
+}
+
+func TestRssiToStrength(t *testing.T) {
+	tests := []struct {
+		rssi     int
+		expected uint8
+	}{
+		{-50, 100},  // Strong signal
+		{-70, 60},   // Medium signal
+		{-90, 20},   // Weak signal
+		{-100, 0},   // Minimum
+		{-110, 0},   // Below minimum
+		{0, 0},      // Invalid
+		{10, 0},     // Invalid positive
+	}
+
+	for _, tt := range tests {
+		result := rssiToStrength(tt.rssi)
+		if result != tt.expected {
+			t.Errorf("rssiToStrength(%d) = %d, want %d", tt.rssi, result, tt.expected)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The macOS `airport` command-line tool has been deprecated and no longer returns WiFi scan results on modern macOS versions. Instead, it only outputs:

```
WARNING: The airport command line tool is deprecated and will be removed in a future release.
For diagnosing Wi-Fi related issues, use the Wireless Diagnostics app or wdutil command line tool.
```

This caused two issues:
- **No signal strength displayed** for any network (all showed 0% or no indicator)
- **All historical networks shown** instead of only visible ones (since the scan returned nothing, only the preferred networks list was displayed)

## Changes

- Replace `airport -s` with `system_profiler SPAirPortDataType` for network scanning
- Add `parseSystemProfilerOutput()` to parse the new output format
- Fix the forget flow to properly remove non-visible forgotten networks from the list
- Add unit tests for the new parsing logic
- Remove the "WARNING: This implementation is untested" comment from darwin.go

## Testing

- [x] `go build` succeeds
- [x] All existing tests pass
- [x] New tests for `parseSystemProfilerOutput()` and `rssiToStrength()` pass
- [x] Manual testing: `wifitui list` now shows signal strength (e.g., "StridhFi 88%, visible, secure, active")
- [x] Manual testing: TUI displays networks with proper signal indicators

## Before/After

**Before:** All networks shown with 0% signal, including networks not in range

**After:** Visible networks show actual signal strength, non-visible saved networks shown without signal indicator