### PR TITLE
fix(cli): populate backend state before ActivateConnection

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -126,6 +126,13 @@ func runConnect(w io.Writer, ssid string, passphrase string, security wifi.Secur
 		return b.JoinNetwork(ssid, passphrase, security, isHidden)
 	}
 
+	// Populate the backend's internal state (e.g. NetworkManager's Connections
+	// and AccessPoints maps) without triggering a new scan.
+	// ActivateConnection relies on this state being present.
+	if _, err := b.BuildNetworkList(false); err != nil {
+		return fmt.Errorf("failed to load networks: %w", err)
+	}
+
 	fmt.Fprintf(w, "Activating existing network %q...\n", ssid)
 	return b.ActivateConnection(ssid)
 }

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -289,12 +289,12 @@ func (b *Backend) BuildNetworkList(shouldScan bool) ([]wifi.Connection, error) {
 			}
 		} else {
 			connInfo = wifi.Connection{
-				SSID:        ssid,
-				IsKnown:     false,
-				IsSecure:    isSecure,
-				IsVisible:   true,
-				Security:    security,
-				AutoConnect: false, // Can't autoconnect to a network we don't know
+				SSID:         ssid,
+				IsKnown:      false,
+				IsSecure:     isSecure,
+				IsVisible:    true,
+				Security:     security,
+				AutoConnect:  false, // Can't autoconnect to a network we don't know
 				AccessPoints: []wifi.AccessPoint{wifiAP},
 			}
 		}


### PR DESCRIPTION
`wifitui connect <ssid>` (without a passphrase) calls ActivateConnection directly. On the NetworkManager backend this looks up the connection and access point in maps that are only populated by BuildNetworkList. The CLI path never called BuildNetworkList, so those maps were always empty and the command always failed with "connection not found".

Call BuildNetworkList(false) immediately before ActivateConnection in the CLI path. No scan is triggered — only the internal state is populated. The JoinNetwork path is left alone; it creates its own unsaved connection and already handles a missing AccessPoint gracefully.