### PR TITLE
Fix debian install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ LATEST_RELEASE="https://github.com/shazow/wifitui/releases/download/${TAG}/wifit
 wget -q -O- "${LATEST_RELEASE}.tar.gz" | tar xzv
 
 # Debian
-sudo apt install "${LATEST_RELEASE}.deb"
+curl -Lfs "${LATEST_RELEASE}.deb" -o /tmp/wifitui.deb
+sudo apt install /tmp/wifitui.deb
+rm -f /tmp/wifitui.deb
 
 # Arch Linux (from AUR)
 yay -S wifitui-bin


### PR DESCRIPTION
This PR curls the latest .deb download and downloads locally before installing with apt, then deleting the file once it's completed.

It fixed #148 