### PR TITLE
Add safe lipgloss renderer to avoid termenv OSC queries on non-TTY outputs

### DIFF
--- a/internal/tui/renderer.go
+++ b/internal/tui/renderer.go
@@ -1,0 +1,26 @@
+package tui
+
+import (
+	"io"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-isatty"
+	"github.com/muesli/termenv"
+)
+
+// newSafeRenderer creates a lipgloss renderer that skips terminal
+// auto-detection (OSC queries) when the writer is not a TTY.
+//
+// Workaround reference: https://github.com/muesli/termenv/issues/205
+func newSafeRenderer(w io.Writer) *lipgloss.Renderer {
+	if f, ok := w.(*os.File); ok && !isatty.IsTerminal(f.Fd()) {
+		return lipgloss.NewRenderer(w, termenv.WithProfile(termenv.Ascii))
+	}
+
+	return lipgloss.NewRenderer(w)
+}
+
+func init() {
+	lipgloss.SetDefaultRenderer(newSafeRenderer(os.Stdout))
+}


### PR DESCRIPTION
### Motivation

- Prevent terminal auto-detection (OSC queries) from running when output is not a TTY to avoid hangs or side-effects in CI and redirected output.
- Work around a known `termenv` issue which triggers terminal queries, as referenced in the code comment.

### Description

- Add `internal/tui/renderer.go` which implements `newSafeRenderer(w io.Writer)` that detects non-TTY `os.File` writers and forces an ASCII `termenv` profile.
- Use `github.com/muesli/termenv` and `github.com/mattn/go-isatty` to detect TTYs and select the `termenv.Ascii` profile when appropriate.
- Register the safe renderer as the default Lipgloss renderer in an `init()` by calling `lipgloss.SetDefaultRenderer(newSafeRenderer(os.Stdout))`.

Fixes #169 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c86771b9808325b9fcad06adb531ce)