### PR TITLE
Check NetworkManager availability, add backend fallback and tests

### DIFF
--- a/backend_linux.go
+++ b/backend_linux.go
@@ -8,11 +8,19 @@ import (
 	"github.com/shazow/wifitui/wifi/networkmanager"
 )
 
+var backends = []func() (wifi.Backend, error){
+	networkmanager.New,
+	iwd.New,
+}
+
 func GetBackend() (wifi.Backend, error) {
-	b, err := networkmanager.New()
-	if err == nil {
-		return b, nil
+	var lastErr error
+	for _, newBackend := range backends {
+		b, err := newBackend()
+		if err == nil {
+			return b, nil
+		}
+		lastErr = err
 	}
-	// If networkmanager dbus backend failed to initialize, try the iwd backend
-	return iwd.New()
+	return nil, lastErr
 }

--- a/backend_linux_test.go
+++ b/backend_linux_test.go
@@ -1,0 +1,33 @@
+//go:build linux && !mock
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shazow/wifitui/wifi"
+	wifimock "github.com/shazow/wifitui/wifi/mock"
+)
+
+func TestGetBackend_FallsBackToIWDWhenNetworkManagerUnavailable(t *testing.T) {
+	origBackends := backends
+	t.Cleanup(func() {
+		backends = origBackends
+	})
+
+	backends = []func() (wifi.Backend, error){
+		func() (wifi.Backend, error) {
+			return nil, errors.New("org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable")
+		},
+		wifimock.New,
+	}
+
+	got, err := GetBackend()
+	if err != nil {
+		t.Fatalf("GetBackend() unexpected error: %v", err)
+	}
+	if _, ok := got.(*wifimock.MockBackend); !ok {
+		t.Fatalf("GetBackend() got %T, want *mock.MockBackend fallback backend", got)
+	}
+}

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -5,6 +5,7 @@ package networkmanager
 import (
 	"fmt"
 	"os/user"
+	"strings"
 	"time"
 
 	gonetworkmanager "github.com/Wifx/gonetworkmanager/v3"
@@ -34,6 +35,16 @@ func New() (wifi.Backend, error) {
 		return nil, fmt.Errorf("failed to create network manager client: %w", wifi.ErrNotAvailable)
 	}
 
+	// gonetworkmanager's constructor only builds a DBus proxy and can succeed even when
+	// NetworkManager is not actually running. Force a lightweight property fetch so we can
+	// fall back to the iwd backend on iwd-only systems.
+	if _, err := nm.GetPropertyVersion(); err != nil {
+		if isUnavailableDBusError(err) {
+			return nil, fmt.Errorf("networkmanager dbus service unavailable: %w: %w", wifi.ErrNotAvailable, err)
+		}
+		return nil, fmt.Errorf("failed to query network manager version: %w: %w", wifi.ErrOperationFailed, err)
+	}
+
 	settings, err := gonetworkmanager.NewSettings()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get settings: %w", wifi.ErrOperationFailed)
@@ -45,6 +56,16 @@ func New() (wifi.Backend, error) {
 		Connections:  make(map[string]gonetworkmanager.Connection),
 		AccessPoints: make(map[string]gonetworkmanager.AccessPoint),
 	}, nil
+}
+
+func isUnavailableDBusError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "org.freedesktop.DBus.Error.ServiceUnknown") ||
+		strings.Contains(msg, "org.freedesktop.DBus.Error.NameHasNoOwner") ||
+		strings.Contains(msg, "The name is not activatable")
 }
 
 func (b *Backend) getWirelessDevice() (gonetworkmanager.DeviceWireless, error) {

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -61,3 +61,44 @@ func TestGetWirelessDevice_Caching(t *testing.T) {
 		t.Errorf("expected 1 call, got %d", callCount)
 	}
 }
+
+func TestIsUnavailableDBusError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "service unknown",
+			err:  testError("org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable"),
+			want: true,
+		},
+		{
+			name: "name has no owner",
+			err:  testError("org.freedesktop.DBus.Error.NameHasNoOwner: Could not get owner"),
+			want: true,
+		},
+		{
+			name: "other error",
+			err:  testError("some other error"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnavailableDBusError(tt.err); got != tt.want {
+				t.Fatalf("isUnavailableDBusError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testError string
+
+func (e testError) Error() string { return string(e) }


### PR DESCRIPTION
### Motivation

- Ensure the app falls back to the iwd backend when NetworkManager's D-Bus service is not actually available even if a client proxy can be constructed. 
- Make backend selection extensible and testable so behavior can be overridden in unit tests.
- Fixes #171 

### Description

- Replace the hard-coded NetworkManager-first initialization with a `backends` slice of constructors and iterate it in `GetBackend()` to return the first successful backend.  
- Add `backend_linux_test.go` with `TestGetBackend_FallsBackToIWDWhenNetworkManagerUnavailable` to verify fallback to the mock/iwd backend when NetworkManager initialization reports an unavailable D-Bus service.  
- In `wifi/networkmanager/networkmanager.go`, force a lightweight `GetPropertyVersion()` call after creating the NetworkManager proxy to detect when the D-Bus service is not actually available, returning `wifi.ErrNotAvailable` for those errors.  
- Add `isUnavailableDBusError()` to classify DBus errors like `ServiceUnknown`, `NameHasNoOwner`, and `The name is not activatable`, and add `TestIsUnavailableDBusError` in `networkmanager_test.go`.  

### Testing

- Ran the new unit tests `TestGetBackend_FallsBackToIWDWhenNetworkManagerUnavailable` and `TestIsUnavailableDBusError` as part of `go test ./...`, and both tests passed.  
- Existing networkmanager unit tests that check device caching still pass after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd661402c483258cb87b5dbc95904b)