### PR TITLE
Default to empty theme when NO_COLOR is set

### DIFF
--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -11,6 +11,11 @@ import (
 
 // Color is a wrapper around lipgloss.TerminalColor that can be unmarshaled
 // from a TOML file as either a single color string or a pair of strings for light/dark themes.
+//
+// FIXME: Is there a way to do the Color struct so that we can safely support
+// an empty Color{}? If so, we can simplify EmptyTheme below. Perhaps by using
+// a concrete type rather than the TerminalColor interface, but not sure of the
+// compatibility implications of that. Need more research.
 type Color struct {
 	lipgloss.TerminalColor
 }
@@ -67,6 +72,21 @@ type Theme struct {
 
 // CurrentTheme is the active theme for the application.
 var CurrentTheme = NewDefaultTheme()
+
+// EmptyTheme is a render-safe minimal theme with no icons.
+// Color is an interface wrapper so we can't just use Theme{} safely, unfortunately.
+var EmptyTheme = Theme{
+	Primary:    Color{lipgloss.NoColor{}},
+	Subtle:     Color{lipgloss.NoColor{}},
+	Success:    Color{lipgloss.NoColor{}},
+	Error:      Color{lipgloss.NoColor{}},
+	Normal:     Color{lipgloss.NoColor{}},
+	Disabled:   Color{lipgloss.NoColor{}},
+	Border:     Color{lipgloss.NoColor{}},
+	SignalHigh: Color{lipgloss.NoColor{}},
+	SignalLow:  Color{lipgloss.NoColor{}},
+	Saved:      Color{lipgloss.NoColor{}},
+}
 
 // NewDefaultTheme creates a new default theme.
 func NewDefaultTheme() Theme {

--- a/main.go
+++ b/main.go
@@ -113,6 +113,10 @@ var opts Options
 
 // Execute is the handler for the "tui" subcommand
 func (c *TuiCommand) Execute(args []string) error {
+	if os.Getenv("NO_COLOR") != "" {
+		// Set empty theme to disable emoji icons when NO_COLOR is requested.
+		tui.CurrentTheme = tui.EmptyTheme
+	}
 	if opts.Theme != "" {
 		f, err := os.Open(opts.Theme)
 		if err != nil {


### PR DESCRIPTION
EmptyTheme removes the default emoji icon values.

Custom theme still overrides this behaviour.

Fixes #176

<img width="1277" height="613" alt="image" src="https://github.com/user-attachments/assets/92218ac1-9f09-4b3c-9181-4a7d7daf2c68" />
