### PR TITLE
Gate NetworkManager tests to Linux to fix Darwin/Nix build

### DIFF
--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package networkmanager
 
 import (


### PR DESCRIPTION
### Motivation
- Prevent Darwin (aarch64-darwin) Nix builds from compiling Linux-only NetworkManager tests that reference symbols (`Backend`, `isUnavailableDBusError`) defined only in the Linux implementation.

### Description
- Add the `//go:build linux` build constraint to `wifi/networkmanager/networkmanager_test.go` so the test file is only compiled on Linux, matching `wifi/networkmanager/networkmanager.go`.

### Testing
- Ran `go test ./...` locally and it passed after the change; `GOOS=darwin GOARCH=arm64 go test ./...` in this Linux environment produced `exec format error` due to cross-arch execution, but the build-tag alignment fixes the original Darwin symbol-mismatch issue observed in the Nix build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f51178aec8325bfbf922f9bcc2371)