### PR TITLE
refactor: Backends and failure tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
           version: v2.17.0
           args: release --clean
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: macos-15-intel
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: v2.17.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: macos-15-intel
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: go test -test.timeout 30s ./...
 
   darwin:
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -36,6 +36,7 @@ jobs:
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
+          ./wifitui --version
       - name: Cross-build for Intel
         env:
           GOARCH: amd64
@@ -57,31 +58,8 @@ jobs:
       - name: Build the native Darwin flake package
         run: |
           native_system="$(nix eval --impure --raw --expr builtins.currentSystem)"
-          test "$native_system" = aarch64-darwin
           package_path="$(nix build ".#packages.${native_system}.default" --no-link --print-out-paths -L)"
           linked_libraries="$(otool -L "$package_path/bin/wifitui")"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
-
-  darwin-latest:
-    runs-on: macos-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-      - name: Run tests with cgo
-        env:
-          CGO_ENABLED: '1'
-        run: go test -test.timeout 30s ./...
-      - name: Build with CoreWLAN
-        run: make build-darwin
-      - name: Verify native CoreWLAN build
-        run: |
-          linked_libraries="$(otool -L ./wifitui)"
-          echo "$linked_libraries"
-          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
-          grep -q '/Foundation.framework/' <<< "$linked_libraries"
-          ./wifitui --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,55 @@ jobs:
           go-version: '1.25'
       - name: Run tests
         run: go test -test.timeout 30s ./...
+
+  darwin:
+    runs-on: macos-15-intel
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Run tests with cgo
+        env:
+          CGO_ENABLED: '1'
+        run: go test -test.timeout 30s ./...
+      - name: Build with CoreWLAN
+        env:
+          CGO_ENABLED: '1'
+        run: make build
+      - name: Verify native CoreWLAN linkage
+        run: |
+          file ./wifitui | grep -q 'x86_64'
+          linked_libraries="$(otool -L ./wifitui)"
+          echo "$linked_libraries"
+          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
+          grep -q '/Foundation.framework/' <<< "$linked_libraries"
+      - name: Cross-build for Apple Silicon
+        env:
+          CGO_ENABLED: '1'
+          GOARCH: arm64
+          GOOS: darwin
+        run: go build -o "$RUNNER_TEMP/wifitui-arm64" .
+      - name: Verify Apple Silicon CoreWLAN linkage
+        run: |
+          file "$RUNNER_TEMP/wifitui-arm64" | grep -q 'arm64'
+          linked_libraries="$(otool -L "$RUNNER_TEMP/wifitui-arm64")"
+          echo "$linked_libraries"
+          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
+          grep -q '/Foundation.framework/' <<< "$linked_libraries"
+      - name: Build release snapshot
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.17.0
+          args: release --snapshot --clean --skip=publish --skip=sign
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Build the native Darwin flake package
+        run: |
+          native_system="$(nix eval --impure --raw --expr builtins.currentSystem)"
+          test "$native_system" = x86_64-darwin
+          package_path="$(nix build ".#packages.${native_system}.default" --no-link --print-out-paths -L)"
+          linked_libraries="$(otool -L "$package_path/bin/wifitui")"
+          echo "$linked_libraries"
+          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
+          grep -q '/Foundation.framework/' <<< "$linked_libraries"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
         run: make build-darwin
       - name: Verify native CoreWLAN linkage
         run: |
-          file ./wifitui | grep -q 'arm64'
           linked_libraries="$(otool -L ./wifitui)"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
@@ -81,8 +80,6 @@ jobs:
         run: make build-darwin
       - name: Verify native CoreWLAN build
         run: |
-          test "$(uname -m)" = arm64
-          file ./wifitui | grep -q 'arm64'
           linked_libraries="$(otool -L ./wifitui)"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: go test -test.timeout 30s ./...
 
   darwin:
-    runs-on: macos-15-intel
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -32,19 +32,19 @@ jobs:
         run: make build-darwin
       - name: Verify native CoreWLAN linkage
         run: |
-          file ./wifitui | grep -q 'x86_64'
+          file ./wifitui | grep -q 'arm64'
           linked_libraries="$(otool -L ./wifitui)"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
-      - name: Cross-build for Apple Silicon
+      - name: Cross-build for Intel
         env:
-          GOARCH: arm64
-        run: make build-darwin BINARY="$RUNNER_TEMP/wifitui-arm64"
-      - name: Verify Apple Silicon CoreWLAN linkage
+          GOARCH: amd64
+        run: make build-darwin BINARY="$RUNNER_TEMP/wifitui-amd64"
+      - name: Verify Intel CoreWLAN linkage
         run: |
-          file "$RUNNER_TEMP/wifitui-arm64" | grep -q 'arm64'
-          linked_libraries="$(otool -L "$RUNNER_TEMP/wifitui-arm64")"
+          file "$RUNNER_TEMP/wifitui-amd64" | grep -q 'x86_64'
+          linked_libraries="$(otool -L "$RUNNER_TEMP/wifitui-amd64")"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
@@ -58,9 +58,33 @@ jobs:
       - name: Build the native Darwin flake package
         run: |
           native_system="$(nix eval --impure --raw --expr builtins.currentSystem)"
-          test "$native_system" = x86_64-darwin
+          test "$native_system" = aarch64-darwin
           package_path="$(nix build ".#packages.${native_system}.default" --no-link --print-out-paths -L)"
           linked_libraries="$(otool -L "$package_path/bin/wifitui")"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
+
+  darwin-latest:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Run tests with cgo
+        env:
+          CGO_ENABLED: '1'
+        run: go test -test.timeout 30s ./...
+      - name: Build with CoreWLAN
+        run: make build-darwin
+      - name: Verify native CoreWLAN build
+        run: |
+          test "$(uname -m)" = arm64
+          file ./wifitui | grep -q 'arm64'
+          linked_libraries="$(otool -L ./wifitui)"
+          echo "$linked_libraries"
+          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
+          grep -q '/Foundation.framework/' <<< "$linked_libraries"
+          ./wifitui --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,7 @@ jobs:
           CGO_ENABLED: '1'
         run: go test -test.timeout 30s ./...
       - name: Build with CoreWLAN
-        env:
-          CGO_ENABLED: '1'
-        run: make build
+        run: make build-darwin
       - name: Verify native CoreWLAN linkage
         run: |
           file ./wifitui | grep -q 'x86_64'
@@ -41,10 +39,8 @@ jobs:
           grep -q '/Foundation.framework/' <<< "$linked_libraries"
       - name: Cross-build for Apple Silicon
         env:
-          CGO_ENABLED: '1'
           GOARCH: arm64
-          GOOS: darwin
-        run: go build -o "$RUNNER_TEMP/wifitui-arm64" .
+        run: make build-darwin BINARY="$RUNNER_TEMP/wifitui-arm64"
       - name: Verify Apple Silicon CoreWLAN linkage
         run: |
           file "$RUNNER_TEMP/wifitui-arm64" | grep -q 'arm64'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+      - name: Check module metadata
+        run: go mod tidy -diff
       - name: Run tests
         run: go test -test.timeout 30s ./...
 
@@ -35,25 +37,12 @@ jobs:
           linked_libraries="$(otool -L ./wifitui)"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
-          grep -q '/Foundation.framework/' <<< "$linked_libraries"
           ./wifitui --version
-      - name: Cross-build for Intel
-        env:
-          GOARCH: amd64
-        run: make build-darwin BINARY="$RUNNER_TEMP/wifitui-amd64"
-      - name: Verify Intel CoreWLAN linkage
-        run: |
-          file "$RUNNER_TEMP/wifitui-amd64" | grep -q 'x86_64'
-          linked_libraries="$(otool -L "$RUNNER_TEMP/wifitui-amd64")"
-          echo "$linked_libraries"
-          grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
-          grep -q '/Foundation.framework/' <<< "$linked_libraries"
       - name: Build release snapshot
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
           version: v2.17.0
-          args: release --snapshot --clean --skip=publish --skip=sign
+          args: release --snapshot --clean --skip=sign
       - uses: DeterminateSystems/nix-installer-action@main
       - name: Build the native Darwin flake package
         run: |
@@ -62,4 +51,3 @@ jobs:
           linked_libraries="$(otool -L "$package_path/bin/wifitui")"
           echo "$linked_libraries"
           grep -q '/CoreWLAN.framework/' <<< "$linked_libraries"
-          grep -q '/Foundation.framework/' <<< "$linked_libraries"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,10 +3,6 @@
 
 version: 2
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: portable
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,11 +8,23 @@ before:
     - go mod tidy
 
 builds:
-  - env:
+  - id: portable
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
       - freebsd
+    goarch:
+      - amd64
+      - arm64
+    main: .
+    binary: wifitui
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+  - id: darwin
+    env:
+      - CGO_ENABLED=1
+    goos:
       - darwin
     goarch:
       - amd64
@@ -37,6 +49,8 @@ changelog:
 
 nfpms:
   - id: wifitui
+    ids:
+      - portable
     maintainer: 'Andrey Petrov'
     description: 'Fast featureful friendly wifi terminal UI. 🛜✨'
     homepage: 'https://github.com/shazow/wifitui'

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 BINARY = wifitui
 
-SRCS = %.go
 VERSION := $(shell git describe --tags --dirty --always 2> /dev/null || echo "dev")
-LDFLAGS = -X main.Version=$(VERSION) -extldflags "-static"
+LDFLAGS = -X main.Version=$(VERSION)
 
-all: $(BINARY)
+.PHONY: all build
 
-$(BINARY): *.go
-	go build -ldflags "$(LDFLAGS)" .
+all: build
 
-build: $(BINARY)
+build:
+	go build -o $(BINARY) -ldflags "$(LDFLAGS)" .
+
+$(BINARY): build
 
 clean:
 	rm $(BINARY)

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
 BINARY = wifitui
 
 VERSION := $(shell git describe --tags --dirty --always 2> /dev/null || echo "dev")
-LDFLAGS = -X main.Version=$(VERSION)
+# Portable builds disable cgo and retain the static external-link preference.
+LDFLAGS = -X main.Version=$(VERSION) -extldflags "-static"
+# CoreWLAN requires cgo and Apple's dynamically linked system frameworks.
+DARWIN_LDFLAGS = -X main.Version=$(VERSION)
 
-.PHONY: all build
+.PHONY: all build build-static build-darwin
 
 all: build
 
-build:
-	go build -o $(BINARY) -ldflags "$(LDFLAGS)" .
+build: build-static
+
+build-static:
+	CGO_ENABLED=0 go build -o $(BINARY) -ldflags "$(LDFLAGS)" .
+
+build-darwin:
+	CGO_ENABLED=1 GOOS=darwin go build -o $(BINARY) -ldflags "$(DARWIN_LDFLAGS)" .
 
 $(BINARY): build
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS = -X main.Version=$(VERSION) -extldflags "-static"
 # CoreWLAN requires cgo and Apple's dynamically linked system frameworks.
 DARWIN_LDFLAGS = -X main.Version=$(VERSION)
 
-.PHONY: all build build-static build-darwin
+.PHONY: all build build-static build-darwin run
 
 all: build
 
@@ -18,12 +18,10 @@ build-static:
 build-darwin:
 	CGO_ENABLED=1 GOOS=darwin go build -o $(BINARY) -ldflags "$(DARWIN_LDFLAGS)" .
 
-$(BINARY): build
-
 clean:
 	rm $(BINARY)
 
-run: $(BINARY)
+run:
 	go run .
 
 mock:

--- a/cli.go
+++ b/cli.go
@@ -93,7 +93,7 @@ func writeNetworkDetails(w io.Writer, c wifi.Network, secret string) error {
 	return writeErr
 }
 
-func runList(w io.Writer, jsonOut bool, all bool, scan bool, b wifi.Backend) error {
+func runList(w io.Writer, errW io.Writer, jsonOut bool, all bool, scan bool, b wifi.Backend) error {
 	scanMode := wifi.ScanNever
 	if scan {
 		scanMode = wifi.ScanForce
@@ -108,6 +108,10 @@ func runList(w io.Writer, jsonOut bool, all bool, scan bool, b wifi.Backend) err
 		networks = filterVisibleNetworks(networks)
 	}
 
+	if result.ScanError != nil {
+		fmt.Fprintf(errW, "Scan failed: %s\n", helpers.FormatScanFailure(result.ScanError))
+	}
+
 	if jsonOut {
 		return writeJSON(w, networks)
 	}
@@ -115,10 +119,6 @@ func runList(w io.Writer, jsonOut bool, all bool, scan bool, b wifi.Backend) err
 	for _, c := range networks {
 		fmt.Fprintf(w, "%s\t%s\n", c.SSID, formatNetwork(c))
 	}
-	if result.ScanError != nil {
-		fmt.Fprintf(w, "Scan failed: %v\n", result.ScanError)
-	}
-
 	return nil
 }
 
@@ -164,15 +164,21 @@ func attemptConnect(ssid string, passphrase string, security wifi.SecurityType, 
 	if shouldScan {
 		scan = wifi.ScanAuto
 	}
-	if _, err := b.ListNetworks(scan); err != nil {
+	result, err := b.ListNetworks(scan)
+	if err != nil {
 		return fmt.Errorf("failed to load networks: %w", err)
 	}
 
+	var connectErr error
 	if passphrase != "" || isHidden {
-		return b.JoinNetwork(ssid, passphrase, security, isHidden)
+		connectErr = b.JoinNetwork(ssid, passphrase, security, isHidden)
+	} else {
+		connectErr = b.ActivateNetwork(ssid)
 	}
-
-	return b.ActivateNetwork(ssid)
+	if connectErr != nil && result.ScanError != nil {
+		return fmt.Errorf("connection failed after scan failure: %w; scan failure: %w", connectErr, result.ScanError)
+	}
+	return connectErr
 }
 
 // RetryConfig defines the configuration for connection retries.

--- a/cli.go
+++ b/cli.go
@@ -109,7 +109,9 @@ func runList(w io.Writer, errW io.Writer, jsonOut bool, all bool, scan bool, b w
 	}
 
 	if result.ScanError != nil {
-		fmt.Fprintf(errW, "Scan failed: %s\n", helpers.FormatScanFailure(result.ScanError))
+		if _, err := fmt.Fprintf(errW, "Scan failed: %s\n", helpers.FormatScanFailure(result.ScanError)); err != nil {
+			return fmt.Errorf("failed to write scan diagnostic: %w", err)
+		}
 	}
 
 	if jsonOut {

--- a/cli.go
+++ b/cli.go
@@ -108,8 +108,8 @@ func runList(w io.Writer, errW io.Writer, jsonOut bool, all bool, scan bool, b w
 		networks = filterVisibleNetworks(networks)
 	}
 
-	if result.ScanError != nil {
-		if _, err := fmt.Fprintf(errW, "Scan failed: %s\n", helpers.FormatScanFailure(result.ScanError)); err != nil {
+	if diagnostic := helpers.FormatScanDiagnostic(result.ScanError, result.IsCached); diagnostic != "" {
+		if _, err := fmt.Fprintln(errW, diagnostic); err != nil {
 			return fmt.Errorf("failed to write scan diagnostic: %w", err)
 		}
 	}

--- a/cli.go
+++ b/cli.go
@@ -115,8 +115,8 @@ func runList(w io.Writer, jsonOut bool, all bool, scan bool, b wifi.Backend) err
 	for _, c := range networks {
 		fmt.Fprintf(w, "%s\t%s\n", c.SSID, formatNetwork(c))
 	}
-	if scan && result.IsCached {
-		fmt.Fprintln(w, "Warning: scan failed; showing cached results")
+	if result.ScanError != nil {
+		fmt.Fprintf(w, "Scan failed: %v\n", result.ScanError)
 	}
 
 	return nil

--- a/cli.go
+++ b/cli.go
@@ -108,8 +108,8 @@ func runList(w io.Writer, errW io.Writer, jsonOut bool, all bool, scan bool, b w
 		networks = filterVisibleNetworks(networks)
 	}
 
-	if diagnostic := helpers.FormatScanDiagnostic(result.ScanError, result.IsCached); diagnostic != "" {
-		if _, err := fmt.Fprintln(errW, diagnostic); err != nil {
+	if result.ScanError != nil {
+		if _, err := fmt.Fprintf(errW, "Scan failed: %s\n", helpers.FormatScanFailure(result.ScanError)); err != nil {
 			return fmt.Errorf("failed to write scan diagnostic: %w", err)
 		}
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ func TestRunListAll(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Test with all=true (should list invisible known networks)
-	if err := runList(&buf, false, true, false, mockBackend); err != nil {
+	if err := runList(&buf, io.Discard, false, true, false, mockBackend); err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}
 
@@ -42,7 +43,7 @@ func TestRunListDefault(t *testing.T) {
 	var buf bytes.Buffer
 
 	// Default behavior (all=false)
-	if err := runList(&buf, false, false, false, mockBackend); err != nil {
+	if err := runList(&buf, io.Discard, false, false, false, mockBackend); err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}
 
@@ -61,11 +62,12 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 		t.Fatalf("failed to create mock backend: %v", err)
 	}
 	var buf bytes.Buffer
+	var errBuf bytes.Buffer
 
 	backend := cachedBackend{
 		Backend: mockBackend,
 	}
-	if err := runList(&buf, false, false, true, backend); err != nil {
+	if err := runList(&buf, &errBuf, false, false, true, backend); err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}
 
@@ -73,8 +75,11 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	if !strings.Contains(output, "Unencrypted_Honeypot") {
 		t.Errorf("runList() output missing cached network. got=%q", output)
 	}
-	if !strings.Contains(output, "Scan failed: scan not allowed") {
-		t.Errorf("runList() output missing scan warning. got=%q", output)
+	if strings.Contains(output, "Scan failed:") {
+		t.Errorf("runList() mixed scan warning into stdout. got=%q", output)
+	}
+	if !strings.Contains(errBuf.String(), "Scan failed: scan not allowed") {
+		t.Errorf("runList() stderr missing scan warning. got=%q", errBuf.String())
 	}
 }
 
@@ -88,7 +93,7 @@ func TestRunListScanForcesRefresh(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := runList(&buf, false, false, true, &backend); err != nil {
+	if err := runList(&buf, io.Discard, false, false, true, &backend); err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}
 	if len(backend.listScans) != 1 || backend.listScans[0] != wifi.ScanForce {
@@ -177,6 +182,49 @@ type scanRecordingBackend struct {
 	listScans []wifi.ScanMode
 }
 
+type scanAndConnectFailureBackend struct {
+	wifi.Backend
+	scanErr       error
+	activationErr error
+}
+
+func (b scanAndConnectFailureBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
+	result, err := b.Backend.ListNetworks(scan)
+	result.ScanError = b.scanErr
+	return result, err
+}
+
+func (b scanAndConnectFailureBackend) ActivateNetwork(string) error {
+	return b.activationErr
+}
+
+func TestAttemptConnectIncludesScanFailureWhenActivationFails(t *testing.T) {
+	mockBackend, err := mock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock backend: %v", err)
+	}
+	scanErr := &wifi.ScanFailure{
+		Backend: "NetworkManager",
+		Stage:   wifi.ScanStageRequest,
+		Cause:   errors.New("scan rejected"),
+	}
+	activationErr := errors.New("activation rejected")
+	backend := scanAndConnectFailureBackend{
+		Backend:       mockBackend,
+		scanErr:       scanErr,
+		activationErr: activationErr,
+	}
+
+	err = attemptConnect("Cafe", "", wifi.SecurityWPA, false, true, backend)
+	if !errors.Is(err, activationErr) {
+		t.Fatalf("attemptConnect() error %v does not retain activation failure", err)
+	}
+	var gotScanFailure *wifi.ScanFailure
+	if !errors.As(err, &gotScanFailure) {
+		t.Fatalf("attemptConnect() error %v does not retain scan failure", err)
+	}
+}
+
 func (b *scanRecordingBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	b.listScans = append(b.listScans, scan)
 	return b.Backend.ListNetworks(scan)
@@ -189,7 +237,7 @@ func TestRunListJSON(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	if err := runList(&buf, true, true, false, mockBackend); err != nil {
+	if err := runList(&buf, io.Discard, true, true, false, mockBackend); err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}
 
@@ -212,6 +260,28 @@ func TestRunListJSON(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("runList() JSON output missing expected network. got=%q", buf.String())
+	}
+}
+
+func TestRunListJSONReportsScanFailureOnStderr(t *testing.T) {
+	mockBackend, err := mock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock backend: %v", err)
+	}
+	var output bytes.Buffer
+	var diagnostics bytes.Buffer
+
+	err = runList(&output, &diagnostics, true, true, true, cachedBackend{Backend: mockBackend})
+	if err != nil {
+		t.Fatalf("runList() failed: %v", err)
+	}
+
+	var networks []wifi.Network
+	if err := json.Unmarshal(output.Bytes(), &networks); err != nil {
+		t.Fatalf("runList() output is not valid JSON: %v. got=%q", err, output.String())
+	}
+	if !strings.Contains(diagnostics.String(), "Scan failed: scan not allowed") {
+		t.Fatalf("runList() stderr missing scan failure. got=%q", diagnostics.String())
 	}
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -73,7 +73,7 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	if !strings.Contains(output, "Unencrypted_Honeypot") {
 		t.Errorf("runList() output missing cached network. got=%q", output)
 	}
-	if !strings.Contains(output, "Warning: scan failed; showing cached results") {
+	if !strings.Contains(output, "Scan failed: scan not allowed") {
 		t.Errorf("runList() output missing scan warning. got=%q", output)
 	}
 }
@@ -168,7 +168,7 @@ type cachedBackend struct {
 
 func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	result, err := b.Backend.ListNetworks(scan)
-	result.IsCached = true
+	result.ScanError = errors.New("scan not allowed")
 	return result, err
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -64,7 +64,7 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	var buf bytes.Buffer
 	var errBuf bytes.Buffer
 
-	backend := cachedBackend{
+	backend := scanFailureBackend{
 		Backend: mockBackend,
 	}
 	if err := runList(&buf, &errBuf, false, false, true, backend); err != nil {
@@ -83,28 +83,13 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	}
 }
 
-func TestRunListShowsLegacyCachedWarning(t *testing.T) {
-	mockBackend, err := mock.New()
-	if err != nil {
-		t.Fatalf("failed to create mock backend: %v", err)
-	}
-	var diagnostics bytes.Buffer
-
-	if err := runList(io.Discard, &diagnostics, false, false, true, legacyCachedBackend{Backend: mockBackend}); err != nil {
-		t.Fatalf("runList() failed: %v", err)
-	}
-	if want := "Scan failed: showing cached results; backend did not provide a failure reason"; !strings.Contains(diagnostics.String(), want) {
-		t.Fatalf("runList() stderr = %q, want %q", diagnostics.String(), want)
-	}
-}
-
 func TestRunListReturnsScanWarningWriteError(t *testing.T) {
 	mockBackend, err := mock.New()
 	if err != nil {
 		t.Fatalf("failed to create mock backend: %v", err)
 	}
 	wantErr := errors.New("write failed")
-	backend := cachedBackend{Backend: mockBackend}
+	backend := scanFailureBackend{Backend: mockBackend}
 
 	err = runList(io.Discard, errorWriter{err: wantErr}, false, false, true, backend)
 	if !errors.Is(err, wantErr) {
@@ -196,24 +181,13 @@ func TestRunShowDoesNotRequestScan(t *testing.T) {
 	}
 }
 
-type cachedBackend struct {
+type scanFailureBackend struct {
 	wifi.Backend
 }
 
-func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
+func (b scanFailureBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	result, err := b.Backend.ListNetworks(scan)
-	result.IsCached = true
 	result.ScanError = errors.New("scan not allowed")
-	return result, err
-}
-
-type legacyCachedBackend struct {
-	wifi.Backend
-}
-
-func (b legacyCachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
-	result, err := b.Backend.ListNetworks(scan)
-	result.IsCached = true
 	return result, err
 }
 
@@ -319,7 +293,7 @@ func TestRunListJSONReportsScanFailureOnStderr(t *testing.T) {
 	var output bytes.Buffer
 	var diagnostics bytes.Buffer
 
-	err = runList(&output, &diagnostics, true, true, true, cachedBackend{Backend: mockBackend})
+	err = runList(&output, &diagnostics, true, true, true, scanFailureBackend{Backend: mockBackend})
 	if err != nil {
 		t.Fatalf("runList() failed: %v", err)
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -83,6 +83,20 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	}
 }
 
+func TestRunListReturnsScanWarningWriteError(t *testing.T) {
+	mockBackend, err := mock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock backend: %v", err)
+	}
+	wantErr := errors.New("write failed")
+	backend := cachedBackend{Backend: mockBackend}
+
+	err = runList(io.Discard, errorWriter{err: wantErr}, false, false, true, backend)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runList() error = %v, want an error wrapping %v", err, wantErr)
+	}
+}
+
 func TestRunListScanForcesRefresh(t *testing.T) {
 	mockBackend, err := mock.New()
 	if err != nil {
@@ -173,8 +187,17 @@ type cachedBackend struct {
 
 func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	result, err := b.Backend.ListNetworks(scan)
+	result.IsCached = true
 	result.ScanError = errors.New("scan not allowed")
 	return result, err
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }
 
 type scanRecordingBackend struct {

--- a/cli_test.go
+++ b/cli_test.go
@@ -83,6 +83,21 @@ func TestRunListShowsScanWarningWithCachedResults(t *testing.T) {
 	}
 }
 
+func TestRunListShowsLegacyCachedWarning(t *testing.T) {
+	mockBackend, err := mock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock backend: %v", err)
+	}
+	var diagnostics bytes.Buffer
+
+	if err := runList(io.Discard, &diagnostics, false, false, true, legacyCachedBackend{Backend: mockBackend}); err != nil {
+		t.Fatalf("runList() failed: %v", err)
+	}
+	if want := "Scan failed: showing cached results; backend did not provide a failure reason"; !strings.Contains(diagnostics.String(), want) {
+		t.Fatalf("runList() stderr = %q, want %q", diagnostics.String(), want)
+	}
+}
+
 func TestRunListReturnsScanWarningWriteError(t *testing.T) {
 	mockBackend, err := mock.New()
 	if err != nil {
@@ -189,6 +204,16 @@ func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, er
 	result, err := b.Backend.ListNetworks(scan)
 	result.IsCached = true
 	result.ScanError = errors.New("scan not allowed")
+	return result, err
+}
+
+type legacyCachedBackend struct {
+	wifi.Backend
+}
+
+func (b legacyCachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
+	result, err := b.Backend.ListNetworks(scan)
+	result.IsCached = true
 	return result, err
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
           src = ./.;
           # Updated by `make vendorHash`
           vendorHash = "sha256-2smXAK3mRweg0yKDerKgu3fcT3ulDjRSbbkMCSe+nVs=";
+          env.CGO_ENABLED = if pkgs.stdenv.isDarwin then "1" else "0";
           ldflags = [
             "-s"
             "-w"

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = [
             pkgs.go
-            pkgs.golint
+            pkgs.go-tools
           ];
         };
       }

--- a/internal/helpers/scan.go
+++ b/internal/helpers/scan.go
@@ -31,3 +31,16 @@ func FormatScanFailure(err error) string {
 		return err.Error()
 	}
 }
+
+// FormatScanDiagnostic returns a complete user-facing scan diagnostic. The
+// cached flag supports backends that implement the deprecated IsCached result
+// field but cannot provide a failure cause.
+func FormatScanDiagnostic(err error, cached bool) string {
+	if err != nil {
+		return "Scan failed: " + FormatScanFailure(err)
+	}
+	if cached {
+		return "Scan failed: showing cached results; backend did not provide a failure reason"
+	}
+	return ""
+}

--- a/internal/helpers/scan.go
+++ b/internal/helpers/scan.go
@@ -31,16 +31,3 @@ func FormatScanFailure(err error) string {
 		return err.Error()
 	}
 }
-
-// FormatScanDiagnostic returns a complete user-facing scan diagnostic. The
-// cached flag supports backends that implement the deprecated IsCached result
-// field but cannot provide a failure cause.
-func FormatScanDiagnostic(err error, cached bool) string {
-	if err != nil {
-		return "Scan failed: " + FormatScanFailure(err)
-	}
-	if cached {
-		return "Scan failed: showing cached results; backend did not provide a failure reason"
-	}
-	return ""
-}

--- a/internal/helpers/scan.go
+++ b/internal/helpers/scan.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/shazow/wifitui/wifi"
+)
+
+// FormatScanFailure returns a concise user-facing explanation while preserving
+// the complete wrapped error for callers that need diagnostic details.
+func FormatScanFailure(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var failure *wifi.ScanFailure
+	_ = errors.As(err, &failure)
+
+	switch {
+	case errors.Is(err, wifi.ErrScanDeviceUnavailable):
+		if failure != nil && failure.Device != "" {
+			return fmt.Sprintf("%s is unavailable", failure.Device)
+		}
+		return "Wi-Fi device is unavailable"
+	case errors.Is(err, wifi.ErrScanPermissionDenied):
+		return "permission denied by the network service"
+	case errors.Is(err, wifi.ErrScanAuthRequired):
+		return "authorization required by the network service"
+	default:
+		return err.Error()
+	}
+}

--- a/internal/helpers/scan_test.go
+++ b/internal/helpers/scan_test.go
@@ -48,3 +48,32 @@ func TestFormatScanFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatScanDiagnostic(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		cached bool
+		want   string
+	}{
+		{
+			name: "detailed failure takes precedence",
+			err:  errors.New("scan not allowed"),
+			want: "Scan failed: scan not allowed",
+		},
+		{
+			name:   "legacy cached result",
+			cached: true,
+			want:   "Scan failed: showing cached results; backend did not provide a failure reason",
+		},
+		{name: "successful result"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatScanDiagnostic(tt.err, tt.cached); got != tt.want {
+				t.Fatalf("FormatScanDiagnostic() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/helpers/scan_test.go
+++ b/internal/helpers/scan_test.go
@@ -48,32 +48,3 @@ func TestFormatScanFailure(t *testing.T) {
 		})
 	}
 }
-
-func TestFormatScanDiagnostic(t *testing.T) {
-	tests := []struct {
-		name   string
-		err    error
-		cached bool
-		want   string
-	}{
-		{
-			name: "detailed failure takes precedence",
-			err:  errors.New("scan not allowed"),
-			want: "Scan failed: scan not allowed",
-		},
-		{
-			name:   "legacy cached result",
-			cached: true,
-			want:   "Scan failed: showing cached results; backend did not provide a failure reason",
-		},
-		{name: "successful result"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := FormatScanDiagnostic(tt.err, tt.cached); got != tt.want {
-				t.Fatalf("FormatScanDiagnostic() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}

--- a/internal/helpers/scan_test.go
+++ b/internal/helpers/scan_test.go
@@ -1,0 +1,50 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/shazow/wifitui/wifi"
+)
+
+func TestFormatScanFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "unavailable device",
+			err: &wifi.ScanFailure{
+				Backend: "NetworkManager",
+				Stage:   wifi.ScanStageRequest,
+				Device:  "wlan0",
+				Cause:   fmt.Errorf("%w: rejected", wifi.ErrScanDeviceUnavailable),
+			},
+			want: "wlan0 is unavailable",
+		},
+		{
+			name: "permission denied through additional wrapping",
+			err:  fmt.Errorf("refresh failed: %w", fmt.Errorf("%w: rejected", wifi.ErrScanPermissionDenied)),
+			want: "permission denied by the network service",
+		},
+		{
+			name: "unknown failure retains context",
+			err: &wifi.ScanFailure{
+				Backend: "iwd",
+				Stage:   wifi.ScanStageRequest,
+				Cause:   errors.New("station rejected request"),
+			},
+			want: "iwd request: station rejected request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatScanFailure(tt.err); got != tt.want {
+				t.Fatalf("FormatScanFailure() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -63,7 +63,6 @@ type (
 	scanFinishedMsg   struct {
 		networks []wifi.Network
 		scanErr  error
-		isCached bool
 	}
 	secretsLoadedMsg struct {
 		item   networkItem

--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -63,6 +63,7 @@ type (
 	scanFinishedMsg   struct {
 		networks []wifi.Network
 		scanErr  error
+		isCached bool
 	}
 	secretsLoadedMsg struct {
 		item   networkItem

--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -62,7 +62,7 @@ type (
 	networksLoadedMsg []wifi.Network // Sent when networks are fetched
 	scanFinishedMsg   struct {
 		networks []wifi.Network
-		isCached bool
+		scanErr  error
 	}
 	secretsLoadedMsg struct {
 		item   networkItem

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/shazow/wifitui/internal/helpers"
 	"github.com/shazow/wifitui/wifi"
 )
 
@@ -285,7 +286,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		m.statusMessage = ""
 		if msg.scanErr != nil {
-			m.statusMessage = fmt.Sprintf("Scan failed: %v", msg.scanErr)
+			m.statusMessage = fmt.Sprintf("Scan failed: %s", helpers.FormatScanFailure(msg.scanErr))
 		}
 	case networkSavedMsg:
 		return m, tea.Batch(

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -166,7 +166,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return scanFinishedMsg{
 				networks: networks,
 				scanErr:  result.ScanError,
-				isCached: result.IsCached,
 			}
 		}
 	case connectMsg:
@@ -286,7 +285,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case scanFinishedMsg:
 		m.loading = false
 		m.statusMessage = ""
-		m.statusMessage = helpers.FormatScanDiagnostic(msg.scanErr, msg.isCached)
+		if msg.scanErr != nil {
+			m.statusMessage = fmt.Sprintf("Scan failed: %s", helpers.FormatScanFailure(msg.scanErr))
+		}
 	case networkSavedMsg:
 		return m, tea.Batch(
 			func() tea.Msg { return statusMsg{status: "Saved. Refreshing...", loading: true} },

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -164,7 +164,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			wifi.SortNetworks(networks)
 			return scanFinishedMsg{
 				networks: networks,
-				isCached: result.IsCached,
+				scanErr:  result.ScanError,
 			}
 		}
 	case connectMsg:
@@ -284,8 +284,8 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case scanFinishedMsg:
 		m.loading = false
 		m.statusMessage = ""
-		if msg.isCached {
-			m.statusMessage = "Warning: scan failed; showing cached results"
+		if msg.scanErr != nil {
+			m.statusMessage = fmt.Sprintf("Scan failed: %v", msg.scanErr)
 		}
 	case networkSavedMsg:
 		return m, tea.Batch(

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -166,6 +166,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return scanFinishedMsg{
 				networks: networks,
 				scanErr:  result.ScanError,
+				isCached: result.IsCached,
 			}
 		}
 	case connectMsg:
@@ -285,9 +286,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case scanFinishedMsg:
 		m.loading = false
 		m.statusMessage = ""
-		if msg.scanErr != nil {
-			m.statusMessage = fmt.Sprintf("Scan failed: %s", helpers.FormatScanFailure(msg.scanErr))
-		}
+		m.statusMessage = helpers.FormatScanDiagnostic(msg.scanErr, msg.isCached)
 	case networkSavedMsg:
 		return m, tea.Batch(
 			func() tea.Msg { return statusMsg{status: "Saved. Refreshing...", loading: true} },

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -76,7 +77,7 @@ func TestTuiModel_ScanWarningKeepsListVisible(t *testing.T) {
 	if !strings.Contains(view, "Unencrypted_Honeypot") {
 		t.Errorf("View does not contain cached network after scan warning in\n%s", view)
 	}
-	if !strings.Contains(view, "Warning: scan failed; showing cached results") {
+	if !strings.Contains(view, "Scan failed: scan not allowed") {
 		t.Errorf("View does not contain scan warning in\n%s", view)
 	}
 	if strings.Contains(view, "Error:") {
@@ -292,7 +293,7 @@ type cachedBackend struct {
 
 func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	result, err := b.Backend.ListNetworks(scan)
-	result.IsCached = true
+	result.ScanError = errors.New("scan not allowed")
 	return result, err
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -56,7 +56,7 @@ func TestTuiModel_ScanWarningKeepsListVisible(t *testing.T) {
 	mockBackend := backend.(*mock.MockBackend)
 	mockBackend.ActionSleep = 0
 
-	m, err := NewModel(cachedBackend{
+	m, err := NewModel(scanFailureBackend{
 		Backend: backend,
 	})
 	if err != nil {
@@ -107,25 +107,6 @@ func TestTuiModel_ScanWarningFormatsUnavailableDevice(t *testing.T) {
 
 	if view := m.View(); !strings.Contains(view, "Scan failed: wlan0 is unavailable") {
 		t.Fatalf("View does not contain formatted unavailable-device failure in\n%s", view)
-	}
-}
-
-func TestTuiModel_LegacyCachedResultShowsWarning(t *testing.T) {
-	backend, err := mock.New()
-	if err != nil {
-		t.Fatalf("mock.New() failed: %v", err)
-	}
-	m, err := NewModel(backend)
-	if err != nil {
-		t.Fatalf("NewModel failed: %v", err)
-	}
-
-	updatedModel, _ := m.Update(scanFinishedMsg{isCached: true})
-	m = updatedModel.(*model)
-
-	want := "Scan failed: showing cached results; backend did not provide a failure reason"
-	if view := m.View(); !strings.Contains(view, want) {
-		t.Fatalf("View does not contain legacy cached-result warning in\n%s", view)
 	}
 }
 
@@ -331,11 +312,11 @@ func TestTuiModel_EnableRadioSwitchesView(t *testing.T) {
 	}
 }
 
-type cachedBackend struct {
+type scanFailureBackend struct {
 	wifi.Backend
 }
 
-func (b cachedBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
+func (b scanFailureBackend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
 	result, err := b.Backend.ListNetworks(scan)
 	result.ScanError = errors.New("scan not allowed")
 	return result, err

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -110,6 +110,25 @@ func TestTuiModel_ScanWarningFormatsUnavailableDevice(t *testing.T) {
 	}
 }
 
+func TestTuiModel_LegacyCachedResultShowsWarning(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	m, err := NewModel(backend)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+
+	updatedModel, _ := m.Update(scanFinishedMsg{isCached: true})
+	m = updatedModel.(*model)
+
+	want := "Scan failed: showing cached results; backend did not provide a failure reason"
+	if view := m.View(); !strings.Contains(view, want) {
+		t.Fatalf("View does not contain legacy cached-result warning in\n%s", view)
+	}
+}
+
 func TestTuiModel_ManualScanForcesRefresh(t *testing.T) {
 	backend, err := mock.New()
 	if err != nil {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -85,6 +85,31 @@ func TestTuiModel_ScanWarningKeepsListVisible(t *testing.T) {
 	}
 }
 
+func TestTuiModel_ScanWarningFormatsUnavailableDevice(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	m, err := NewModel(backend)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+
+	updatedModel, _ := m.Update(scanFinishedMsg{
+		scanErr: &wifi.ScanFailure{
+			Backend: "NetworkManager",
+			Stage:   wifi.ScanStageRequest,
+			Device:  "wlan0",
+			Cause:   wifi.ErrScanDeviceUnavailable,
+		},
+	})
+	m = updatedModel.(*model)
+
+	if view := m.View(); !strings.Contains(view, "Scan failed: wlan0 is unavailable") {
+		t.Fatalf("View does not contain formatted unavailable-device failure in\n%s", view)
+	}
+}
+
 func TestTuiModel_ManualScanForcesRefresh(t *testing.T) {
 	backend, err := mock.New()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func (c *TuiCommand) Execute(args []string) error {
 
 // Execute is the handler for the "list" subcommand
 func (c *ListCommand) Execute(args []string) error {
-	return runList(os.Stdout, c.JSON, c.All, c.Scan, b)
+	return runList(os.Stdout, os.Stderr, c.JSON, c.All, c.Scan, b)
 }
 
 // Execute is the handler for the "show" subcommand

--- a/wifi/backend.go
+++ b/wifi/backend.go
@@ -100,11 +100,6 @@ const (
 // NetworksResult contains the networks returned by a list operation.
 type NetworksResult struct {
 	Networks []Network
-	// IsCached reports whether Networks contains fallback data after a requested
-	// scan failed.
-	//
-	// Deprecated: inspect ScanError instead.
-	IsCached bool
 	// ScanError is non-nil when a requested scan failed and Networks contains
 	// fallback data instead.
 	ScanError error

--- a/wifi/backend.go
+++ b/wifi/backend.go
@@ -100,8 +100,13 @@ const (
 // NetworksResult contains the networks returned by a list operation.
 type NetworksResult struct {
 	Networks []Network
+	// IsCached reports whether Networks contains fallback data after a requested
+	// scan failed.
+	//
+	// Deprecated: inspect ScanError instead.
+	IsCached bool
 	// ScanError is non-nil when a requested scan failed and Networks contains
-	// cached results instead.
+	// fallback data instead.
 	ScanError error
 }
 

--- a/wifi/backend.go
+++ b/wifi/backend.go
@@ -97,11 +97,12 @@ const (
 	ScanForce
 )
 
-// NetworksResult contains the networks returned by a list operation and
-// whether they came from a cached fallback after a requested scan failed.
+// NetworksResult contains the networks returned by a list operation.
 type NetworksResult struct {
 	Networks []Network
-	IsCached bool
+	// ScanError is non-nil when a requested scan failed and Networks contains
+	// cached results instead.
+	ScanError error
 }
 
 // Backend defines the interface for managing Wi-Fi networks.

--- a/wifi/darwin/corewlan_bridge.h
+++ b/wifi/darwin/corewlan_bridge.h
@@ -1,0 +1,10 @@
+#ifndef WIFITUI_COREWLAN_BRIDGE_H
+#define WIFITUI_COREWLAN_BRIDGE_H
+
+// Returns 0 on success, or one of the status values mirrored in
+// coreWLANStatusError. The caller owns returned strings and must release them
+// with wifitui_corewlan_free.
+int wifitui_corewlan_scan(const char *device, char **output, char **error_message);
+void wifitui_corewlan_free(char *value);
+
+#endif

--- a/wifi/darwin/corewlan_bridge_darwin.m
+++ b/wifi/darwin/corewlan_bridge_darwin.m
@@ -1,0 +1,153 @@
+//go:build darwin && cgo
+
+#import <CoreWLAN/CoreWLAN.h>
+#import <Foundation/Foundation.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "corewlan_bridge.h"
+
+static void wifitui_set_error(char **destination, NSString *message) {
+    if (destination == NULL || message == nil) {
+        return;
+    }
+    *destination = strdup(message.UTF8String);
+}
+
+static NSString *wifitui_security(CWNetwork *network) {
+    if ([network supportsSecurity:kCWSecurityNone]) {
+        return @"open";
+    }
+    if ([network supportsSecurity:kCWSecurityWEP] ||
+        [network supportsSecurity:kCWSecurityDynamicWEP]) {
+        return @"wep";
+    }
+    if ([network supportsSecurity:kCWSecurityUnknown]) {
+        return @"unknown";
+    }
+    return @"wpa";
+}
+
+static NSNumber *wifitui_frequency(CWNetwork *network) {
+    CWChannel *channel = network.wlanChannel;
+    if (channel == nil) {
+        return @0;
+    }
+    NSInteger number = channel.channelNumber;
+    switch (channel.channelBand) {
+        case kCWChannelBand2GHz:
+            if (number == 14) {
+                return @2484;
+            }
+            if (number >= 1 && number <= 13) {
+                return @(2407 + 5 * number);
+            }
+            break;
+        case kCWChannelBand5GHz:
+            if (number > 0) {
+                return @(5000 + 5 * number);
+            }
+            break;
+#if defined(__MAC_13_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0
+        case kCWChannelBand6GHz:
+            if (number > 0) {
+                return @(5950 + 5 * number);
+            }
+            break;
+#endif
+        default:
+            break;
+    }
+    return @0;
+}
+
+int wifitui_corewlan_scan(const char *device, char **output, char **error_message) {
+    @autoreleasepool {
+        if (output != NULL) {
+            *output = NULL;
+        }
+        if (error_message != NULL) {
+            *error_message = NULL;
+        }
+
+        NSString *device_name = device == NULL ? nil : [NSString stringWithUTF8String:device];
+        CWInterface *interface = [[CWWiFiClient sharedWiFiClient] interfaceWithName:device_name];
+        if (interface == nil) {
+            wifitui_set_error(error_message, [NSString stringWithFormat:@"CoreWLAN interface %@ is unavailable", device_name]);
+            return 1;
+        }
+
+        NSError *scan_error = nil;
+        NSSet<CWNetwork *> *networks = [interface scanForNetworksWithName:nil error:&scan_error];
+        if (networks == nil) {
+            NSString *message = scan_error == nil
+                ? @"CoreWLAN returned neither scan results nor an error"
+                : [NSString stringWithFormat:@"CoreWLAN scan failed: %@ (%@:%ld)",
+                    scan_error.localizedDescription, scan_error.domain, (long)scan_error.code];
+            wifitui_set_error(error_message, message);
+            if ([scan_error.domain isEqualToString:CWErrorDomain]) {
+                switch ((CWErr)scan_error.code) {
+                    case kCWOperationNotPermittedErr:
+                        return 4;
+                    case kCWTimeoutErr:
+                    case kCWSupplicantTimeoutErr:
+                        return 5;
+                    case kCWNotSupportedErr:
+                        return 6;
+                    default:
+                        break;
+                }
+            }
+            return 2;
+        }
+
+        NSMutableArray<NSDictionary *> *serialized = [NSMutableArray arrayWithCapacity:networks.count];
+        for (CWNetwork *network in networks) {
+            NSString *ssid = network.ssid;
+            if (ssid == nil || ssid.length == 0) {
+                continue;
+            }
+            [serialized addObject:@{
+                @"ssid": ssid,
+                @"bssid": network.bssid ?: @"",
+                @"security": wifitui_security(network),
+                @"rssi": @(network.rssiValue),
+                @"frequency": wifitui_frequency(network),
+            }];
+        }
+        if (networks.count > 0 && serialized.count == 0) {
+            wifitui_set_error(error_message,
+                @"CoreWLAN returned networks without SSIDs; Location Services permission may be required");
+            return 4;
+        }
+
+        NSError *json_error = nil;
+        NSData *json_data = [NSJSONSerialization dataWithJSONObject:serialized options:0 error:&json_error];
+        if (json_data == nil) {
+            NSString *message = json_error == nil
+                ? @"CoreWLAN results could not be serialized"
+                : [NSString stringWithFormat:@"CoreWLAN results could not be serialized: %@",
+                    json_error.localizedDescription];
+            wifitui_set_error(error_message, message);
+            return 3;
+        }
+
+        if (output != NULL) {
+            NSUInteger length = json_data.length;
+            char *json = malloc(length + 1);
+            if (json == NULL) {
+                wifitui_set_error(error_message, @"CoreWLAN result JSON could not be allocated");
+                return 3;
+            }
+            memcpy(json, json_data.bytes, length);
+            json[length] = '\0';
+            *output = json;
+        }
+        return 0;
+    }
+}
+
+void wifitui_corewlan_free(char *value) {
+    free(value);
+}

--- a/wifi/darwin/corewlan_darwin_cgo.go
+++ b/wifi/darwin/corewlan_darwin_cgo.go
@@ -1,0 +1,41 @@
+//go:build darwin && cgo
+
+package darwin
+
+/*
+#cgo LDFLAGS: -framework CoreWLAN -framework Foundation
+#include <stdlib.h>
+#include "corewlan_bridge.h"
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+func scanVisibleNetworks(device string) ([]scannedNetwork, error) {
+	cDevice := C.CString(device)
+	defer C.free(unsafe.Pointer(cDevice))
+
+	var output *C.char
+	var errorMessage *C.char
+	status := C.wifitui_corewlan_scan(cDevice, &output, &errorMessage)
+	if output != nil {
+		defer C.wifitui_corewlan_free(output)
+	}
+	if errorMessage != nil {
+		defer C.wifitui_corewlan_free(errorMessage)
+	}
+
+	if status != coreWLANStatusSuccess {
+		message := "CoreWLAN scan failed"
+		if errorMessage != nil {
+			message = C.GoString(errorMessage)
+		}
+		return nil, coreWLANStatusError(int(status), message)
+	}
+	if output == nil {
+		return nil, coreWLANStatusError(coreWLANStatusProtocol, "CoreWLAN returned an empty response")
+	}
+	return decodeCoreWLANScan([]byte(C.GoString(output)))
+}

--- a/wifi/darwin/corewlan_darwin_nocgo.go
+++ b/wifi/darwin/corewlan_darwin_nocgo.go
@@ -1,0 +1,13 @@
+//go:build darwin && !cgo
+
+package darwin
+
+import (
+	"fmt"
+
+	"github.com/shazow/wifitui/wifi"
+)
+
+func scanVisibleNetworks(string) ([]scannedNetwork, error) {
+	return nil, fmt.Errorf("CoreWLAN scanning requires cgo: %w", wifi.ErrNotSupported)
+}

--- a/wifi/darwin/corewlan_other.go
+++ b/wifi/darwin/corewlan_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package darwin
+
+import (
+	"fmt"
+
+	"github.com/shazow/wifitui/wifi"
+)
+
+func scanVisibleNetworks(string) ([]scannedNetwork, error) {
+	return nil, fmt.Errorf("CoreWLAN scanning is only available on macOS: %w", wifi.ErrNotSupported)
+}

--- a/wifi/darwin/darwin.go
+++ b/wifi/darwin/darwin.go
@@ -3,36 +3,12 @@
 package darwin
 
 import (
-	"bufio"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/shazow/wifitui/wifi"
 )
-
-// runWithOutput wraps exec.Command to capture stderr and wrap errors.
-func runWithOutput(c *exec.Cmd) ([]byte, error) {
-	var stderr strings.Builder
-	c.Stderr = &stderr
-	out, err := c.Output()
-	if err != nil {
-		return out, fmt.Errorf("failed to run command: %s: %w: %s", c.String(), err, stderr.String())
-	}
-	return out, nil
-}
-
-// runOnly wraps exec.Command for commands where we don't care about stdout.
-func runOnly(c *exec.Cmd) error {
-	var stderr strings.Builder
-	c.Stderr = &stderr
-	err := c.Run()
-	if err != nil {
-		return fmt.Errorf("failed to run command: %s: %w: %s", c.String(), err, stderr.String())
-	}
-	return nil
-}
 
 // Backend implements the wifi.Backend interface for macOS.
 type Backend struct {
@@ -58,115 +34,9 @@ func New() (wifi.Backend, error) {
 
 // ListNetworks returns all networks.
 func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
-	enabled, err := b.IsWirelessEnabled()
-	if err != nil {
-		return wifi.NetworksResult{}, err
-	}
-	if !enabled {
-		return wifi.NetworksResult{}, wifi.ErrWirelessDisabled
-	}
-
-	// Get current network
-	cmd := exec.Command("networksetup", "-getairportnetwork", b.WifiInterface)
-	out, err := runWithOutput(cmd)
-	var currentSSID string
-	if err == nil {
-		re := regexp.MustCompile(`Current Wi-Fi Network: (.+)`)
-		matches := re.FindStringSubmatch(string(out))
-		if len(matches) > 1 {
-			currentSSID = strings.TrimSpace(matches[1])
-		}
-	}
-
-	// Get known networks
-	cmd = exec.Command("networksetup", "-listpreferredwirelessnetworks", b.WifiInterface)
-	out, err = runWithOutput(cmd)
-	if err != nil {
-		return wifi.NetworksResult{}, fmt.Errorf("failed to list preferred networks: %w: %w", wifi.ErrOperationFailed, err)
-	}
-	knownSSIDs := make(map[string]bool)
-	scanner := bufio.NewScanner(strings.NewReader(string(out)))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" && !strings.HasPrefix(line, "Preferred") {
-			knownSSIDs[line] = true
-		}
-	}
-
-	// Scan for visible networks using system_profiler (airport command is deprecated)
-	cmd = exec.Command("system_profiler", "SPAirPortDataType")
-	out, err = runWithOutput(cmd)
-	if err != nil {
-		var conns []wifi.Network
-		for ssid := range knownSSIDs {
-			conns = append(conns, wifi.Network{
-				SSID:        ssid,
-				IsActive:    ssid == currentSSID,
-				IsKnown:     true,
-				AutoConnect: true,
-			})
-		}
-		wifi.SortNetworks(conns)
-		return wifi.NetworksResult{
-			Networks: conns,
-			ScanError: &wifi.ScanFailure{
-				Backend: "macOS",
-				Stage:   wifi.ScanStageRequest,
-				Device:  b.WifiInterface,
-				Cause:   err,
-			},
-		}, nil
-	}
-
-	scannedNetworks := parseSystemProfilerOutput(string(out))
-
-	// Aggregate networks by SSID
-	aggregatedConns := make(map[string]wifi.Network)
-
-	for _, net := range scannedNetworks {
-		isKnown := knownSSIDs[net.ssid]
-		isActive := net.isActive || net.ssid == currentSSID
-
-		ap := wifi.AccessPoint{Strength: rssiToStrength(net.rssi)}
-
-		if conn, exists := aggregatedConns[net.ssid]; exists {
-			conn.AccessPoints = append(conn.AccessPoints, ap)
-			// Merge flags if necessary (e.g. if one BSSID is active, the whole SSID is active)
-			if isActive {
-				conn.IsActive = true
-			}
-			aggregatedConns[net.ssid] = conn
-		} else {
-			aggregatedConns[net.ssid] = wifi.Network{
-				SSID:         net.ssid,
-				IsActive:     isActive,
-				IsKnown:      isKnown,
-				IsVisible:    true,
-				AccessPoints: []wifi.AccessPoint{ap},
-				IsSecure:     net.security != wifi.SecurityOpen,
-				Security:     net.security,
-				AutoConnect:  isKnown,
-			}
-		}
-	}
-
-	var conns []wifi.Network
-	for _, conn := range aggregatedConns {
-		conns = append(conns, conn)
-	}
-
-	// Add known networks that are not visible
-	for ssid := range knownSSIDs {
-		if _, exists := aggregatedConns[ssid]; !exists {
-			conns = append(conns, wifi.Network{
-				SSID:        ssid,
-				IsKnown:     true,
-				AutoConnect: true,
-			})
-		}
-	}
-
-	return wifi.NetworksResult{Networks: conns}, nil
+	return listNetworks(func(name string, args ...string) ([]byte, error) {
+		return runWithOutput(exec.Command(name, args...))
+	}, b.WifiInterface, scan)
 }
 
 // ActivateNetwork activates a known network.

--- a/wifi/darwin/darwin.go
+++ b/wifi/darwin/darwin.go
@@ -10,11 +10,6 @@ import (
 	"github.com/shazow/wifitui/wifi"
 )
 
-// Backend implements the wifi.Backend interface for macOS.
-type Backend struct {
-	WifiInterface string
-}
-
 // New creates a new darwin.Backend.
 func New() (wifi.Backend, error) {
 	// Find the Wi-Fi interface name (e.g., en0)
@@ -30,13 +25,6 @@ func New() (wifi.Backend, error) {
 	}
 
 	return &Backend{WifiInterface: device}, nil
-}
-
-// ListNetworks returns all networks.
-func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
-	return listNetworks(func(name string, args ...string) ([]byte, error) {
-		return runWithOutput(exec.Command(name, args...))
-	}, b.WifiInterface, scan)
 }
 
 // ActivateNetwork activates a known network.

--- a/wifi/darwin/darwin.go
+++ b/wifi/darwin/darwin.go
@@ -45,7 +45,7 @@ func New() (wifi.Backend, error) {
 	cmd := exec.Command("networksetup", "-listallhardwareports")
 	out, err := runWithOutput(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list hardware ports: %w", wifi.ErrOperationFailed)
+		return nil, fmt.Errorf("failed to list hardware ports: %w: %w", wifi.ErrOperationFailed, err)
 	}
 
 	device, err := findWifiDevice(string(out))
@@ -82,7 +82,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 	cmd = exec.Command("networksetup", "-listpreferredwirelessnetworks", b.WifiInterface)
 	out, err = runWithOutput(cmd)
 	if err != nil {
-		return wifi.NetworksResult{}, fmt.Errorf("failed to list preferred networks: %w: %s", wifi.ErrOperationFailed, err)
+		return wifi.NetworksResult{}, fmt.Errorf("failed to list preferred networks: %w: %w", wifi.ErrOperationFailed, err)
 	}
 	knownSSIDs := make(map[string]bool)
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
@@ -97,7 +97,25 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 	cmd = exec.Command("system_profiler", "SPAirPortDataType")
 	out, err = runWithOutput(cmd)
 	if err != nil {
-		return wifi.NetworksResult{}, fmt.Errorf("failed to scan for networks: %w", wifi.ErrOperationFailed)
+		var conns []wifi.Network
+		for ssid := range knownSSIDs {
+			conns = append(conns, wifi.Network{
+				SSID:        ssid,
+				IsActive:    ssid == currentSSID,
+				IsKnown:     true,
+				AutoConnect: true,
+			})
+		}
+		wifi.SortNetworks(conns)
+		return wifi.NetworksResult{
+			Networks: conns,
+			ScanError: &wifi.ScanFailure{
+				Backend: "macOS",
+				Stage:   wifi.ScanStageRequest,
+				Device:  b.WifiInterface,
+				Cause:   err,
+			},
+		}, nil
 	}
 
 	scannedNetworks := parseSystemProfilerOutput(string(out))

--- a/wifi/darwin/darwin_logic.go
+++ b/wifi/darwin/darwin_logic.go
@@ -2,11 +2,13 @@ package darwin
 
 import (
 	"bufio"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/shazow/wifitui/wifi"
 )
@@ -33,20 +35,113 @@ func runOnly(command *exec.Cmd) error {
 }
 
 type scannedNetwork struct {
-	ssid     string
-	security wifi.SecurityType
-	rssi     int
-	isActive bool
+	ssid      string
+	bssid     string
+	security  wifi.SecurityType
+	rssi      int
+	frequency uint
+}
+
+type coreWLANNetwork struct {
+	SSID      string `json:"ssid"`
+	BSSID     string `json:"bssid"`
+	Security  string `json:"security"`
+	RSSI      int    `json:"rssi"`
+	Frequency uint   `json:"frequency"`
+}
+
+const (
+	coreWLANStatusSuccess = iota
+	coreWLANStatusDeviceUnavailable
+	coreWLANStatusFailed
+	coreWLANStatusProtocol
+	coreWLANStatusPermissionDenied
+	coreWLANStatusTimeout
+	coreWLANStatusUnsupported
+)
+
+func coreWLANStatusError(status int, message string) error {
+	classification := error(nil)
+	switch status {
+	case coreWLANStatusDeviceUnavailable:
+		classification = wifi.ErrScanDeviceUnavailable
+	case coreWLANStatusProtocol:
+		classification = wifi.ErrScanProtocol
+	case coreWLANStatusPermissionDenied:
+		classification = wifi.ErrScanPermissionDenied
+	case coreWLANStatusTimeout:
+		classification = wifi.ErrScanTimeout
+	case coreWLANStatusUnsupported:
+		classification = wifi.ErrNotSupported
+	}
+	if classification == nil {
+		return errors.New(message)
+	}
+	return fmt.Errorf("%s: %w", message, classification)
+}
+
+func decodeCoreWLANScan(output []byte) ([]scannedNetwork, error) {
+	var decoded []coreWLANNetwork
+	if err := json.Unmarshal(output, &decoded); err != nil {
+		return nil, fmt.Errorf("%w: decode CoreWLAN results: %w", wifi.ErrScanProtocol, err)
+	}
+
+	networks := make([]scannedNetwork, 0, len(decoded))
+	for _, network := range decoded {
+		if network.SSID == "" {
+			continue
+		}
+		security := wifi.SecurityUnknown
+		switch network.Security {
+		case "open":
+			security = wifi.SecurityOpen
+		case "wep":
+			security = wifi.SecurityWEP
+		case "wpa":
+			security = wifi.SecurityWPA
+		}
+		networks = append(networks, scannedNetwork{
+			ssid:      network.SSID,
+			bssid:     network.BSSID,
+			security:  security,
+			rssi:      network.RSSI,
+			frequency: network.Frequency,
+		})
+	}
+	if len(decoded) > 0 && len(networks) == 0 {
+		return nil, fmt.Errorf("%w: CoreWLAN returned networks without an SSID", wifi.ErrScanProtocol)
+	}
+	return networks, nil
 }
 
 type outputRunner func(name string, args ...string) ([]byte, error)
+type networkScanner func(device string) ([]scannedNetwork, error)
+
+// Backend implements wifi.Backend for macOS. A Backend must not be copied after
+// first use. The command and scan functions are injectable so orchestration and
+// cache behavior can be tested on any OS.
+type Backend struct {
+	WifiInterface string
+
+	runOutput    outputRunner
+	scanNetworks networkScanner
+
+	cacheMu     sync.RWMutex
+	lastVisible []wifi.Network
+}
 
 var currentNetworkRE = regexp.MustCompile(`Current Wi-Fi Network: (.+)`)
 
-// listNetworks contains the command orchestration separately from the
-// Darwin-specific exec implementation so its behavior can be tested on any OS.
-func listNetworks(run outputRunner, device string, scan wifi.ScanMode) (wifi.NetworksResult, error) {
-	out, err := run("networksetup", "-getairportpower", device)
+// ListNetworks returns the current network list and optionally scans first.
+func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) {
+	run := b.runOutput
+	if run == nil {
+		run = func(name string, args ...string) ([]byte, error) {
+			return runWithOutput(exec.Command(name, args...))
+		}
+	}
+
+	out, err := run("networksetup", "-getairportpower", b.WifiInterface)
 	if err != nil {
 		return wifi.NetworksResult{}, fmt.Errorf("failed to get wireless power: %w", err)
 	}
@@ -54,10 +149,10 @@ func listNetworks(run outputRunner, device string, scan wifi.ScanMode) (wifi.Net
 		return wifi.NetworksResult{}, wifi.ErrWirelessDisabled
 	}
 
-	// The association query is best effort: preferred networks and profiler
+	// The association query is best effort: preferred networks and scan
 	// results are still useful without it. If fallback is also needed, preserve
 	// both failures in ScanError because the missing association degrades it.
-	currentOut, currentErr := run("networksetup", "-getairportnetwork", device)
+	currentOut, currentErr := run("networksetup", "-getairportnetwork", b.WifiInterface)
 	currentSSID := ""
 	if currentErr == nil {
 		matches := currentNetworkRE.FindStringSubmatch(string(currentOut))
@@ -66,240 +161,184 @@ func listNetworks(run outputRunner, device string, scan wifi.ScanMode) (wifi.Net
 		}
 	}
 
-	preferredOut, err := run("networksetup", "-listpreferredwirelessnetworks", device)
+	preferredOut, err := run("networksetup", "-listpreferredwirelessnetworks", b.WifiInterface)
 	if err != nil {
 		return wifi.NetworksResult{}, fmt.Errorf("failed to list preferred networks: %w: %w", wifi.ErrOperationFailed, err)
 	}
 	knownSSIDs := parsePreferredNetworks(string(preferredOut))
 
 	if scan == wifi.ScanNever {
-		return wifi.NetworksResult{Networks: fallbackNetworks(knownSSIDs, currentSSID)}, nil
+		return wifi.NetworksResult{Networks: mergeNetworks(b.cachedNetworks(), knownSSIDs, currentSSID)}, nil
 	}
 
-	// TODO: Use CoreWLAN for a true scan and retain its last successful snapshot.
-	// system_profiler cannot distinguish ScanAuto from ScanForce and does not
-	// guarantee that collecting its report initiates a new wireless scan.
-	profilerOut, err := run("system_profiler", "SPAirPortDataType")
+	scanner := b.scanNetworks
+	if scanner == nil {
+		scanner = scanVisibleNetworks
+	}
+	scanned, err := scanner(b.WifiInterface)
 	if err != nil {
 		cause := err
-		if currentErr != nil {
-			cause = fmt.Errorf("system report failed: %w; current network query also failed: %w", err, currentErr)
+		stage := wifi.ScanStageRequest
+		if errors.Is(err, wifi.ErrScanProtocol) || errors.Is(err, wifi.ErrScanTimeout) {
+			stage = wifi.ScanStageCompletion
 		}
-		return wifi.NetworksResult{
-			Networks: fallbackNetworks(knownSSIDs, currentSSID),
-			IsCached: true,
-			ScanError: &wifi.ScanFailure{
-				Backend: "macOS",
-				Stage:   wifi.ScanStageRequest,
-				Device:  device,
-				Cause:   cause,
-			},
-		}, nil
+		if currentErr != nil {
+			cause = fmt.Errorf("scan failed: %w; current network query also failed: %w", err, currentErr)
+		}
+		return b.scanFallback(b.cachedNetworks(), knownSSIDs, currentSSID, stage, cause), nil
 	}
-
-	return wifi.NetworksResult{Networks: aggregateNetworks(
-		parseSystemProfilerOutput(string(profilerOut)), knownSSIDs, currentSSID,
-	)}, nil
+	visible := visibleNetworks(scanned)
+	if len(scanned) > 0 && len(visible) == 0 {
+		cause := fmt.Errorf("%w: scan returned no networks with an SSID", wifi.ErrScanProtocol)
+		return b.scanFallback(b.cachedNetworks(), knownSSIDs, currentSSID, wifi.ScanStageCompletion, cause), nil
+	}
+	b.storeNetworks(visible)
+	return wifi.NetworksResult{Networks: mergeNetworks(visible, knownSSIDs, currentSSID)}, nil
 }
 
 func parsePreferredNetworks(output string) map[string]bool {
 	knownSSIDs := make(map[string]bool)
 	scanner := bufio.NewScanner(strings.NewReader(output))
+	firstNonEmpty := true
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line != "" && !strings.HasPrefix(line, "Preferred") {
-			knownSSIDs[line] = true
+		if line == "" {
+			continue
 		}
+		if firstNonEmpty {
+			firstNonEmpty = false
+			if strings.HasPrefix(line, "Preferred networks on ") && strings.HasSuffix(line, ":") {
+				continue
+			}
+		}
+		knownSSIDs[line] = true
 	}
 	return knownSSIDs
 }
 
-func fallbackNetworks(knownSSIDs map[string]bool, currentSSID string) []wifi.Network {
-	networksBySSID := make(map[string]wifi.Network, len(knownSSIDs)+1)
-	for ssid := range knownSSIDs {
-		networksBySSID[ssid] = wifi.Network{
-			SSID:        ssid,
-			IsKnown:     true,
-			AutoConnect: true,
-		}
+func (b *Backend) scanFallback(cached []wifi.Network, knownSSIDs map[string]bool, currentSSID string, stage wifi.ScanStage, cause error) wifi.NetworksResult {
+	return wifi.NetworksResult{
+		Networks: mergeNetworks(cached, knownSSIDs, currentSSID),
+		IsCached: true,
+		ScanError: &wifi.ScanFailure{
+			Backend: "macOS",
+			Stage:   stage,
+			Device:  b.WifiInterface,
+			Cause:   cause,
+		},
 	}
-	if currentSSID != "" {
-		current := networksBySSID[currentSSID]
-		current.SSID = currentSSID
-		current.IsActive = true
-		current.IsVisible = true
-		networksBySSID[currentSSID] = current
-	}
-	return sortedNetworks(networksBySSID)
 }
 
-func aggregateNetworks(scanned []scannedNetwork, knownSSIDs map[string]bool, currentSSID string) []wifi.Network {
-	networksBySSID := make(map[string]wifi.Network, len(scanned)+len(knownSSIDs)+1)
+func visibleNetworks(scanned []scannedNetwork) []wifi.Network {
+	networksByKey := make(map[darwinNetworkKey]wifi.Network, len(scanned))
 	for _, network := range scanned {
-		known := knownSSIDs[network.ssid]
-		active := network.isActive || network.ssid == currentSSID
-		accessPoint := wifi.AccessPoint{Strength: rssiToStrength(network.rssi)}
-		if existing, ok := networksBySSID[network.ssid]; ok {
-			existing.AccessPoints = append(existing.AccessPoints, accessPoint)
-			existing.IsActive = existing.IsActive || active
-			networksBySSID[network.ssid] = existing
+		if network.ssid == "" {
 			continue
 		}
-		networksBySSID[network.ssid] = wifi.Network{
+		accessPoint := wifi.AccessPoint{
+			SSID:      network.ssid,
+			BSSID:     network.bssid,
+			Strength:  rssiToStrength(network.rssi),
+			Frequency: network.frequency,
+		}
+		key := darwinNetworkKey{ssid: network.ssid, security: network.security}
+		if existing, ok := networksByKey[key]; ok {
+			existing.AccessPoints = append(existing.AccessPoints, accessPoint)
+			networksByKey[key] = existing
+			continue
+		}
+		networksByKey[key] = wifi.Network{
 			SSID:         network.ssid,
-			IsActive:     active,
-			IsKnown:      known,
 			IsVisible:    true,
 			AccessPoints: []wifi.AccessPoint{accessPoint},
 			IsSecure:     network.security != wifi.SecurityOpen,
 			Security:     network.security,
-			AutoConnect:  known,
 		}
 	}
+	return sortedNetworks(networksByKey)
+}
 
-	if currentSSID != "" {
-		current := networksBySSID[currentSSID]
-		current.SSID = currentSSID
-		current.IsActive = true
-		current.IsVisible = true
-		current.IsKnown = knownSSIDs[currentSSID]
-		current.AutoConnect = current.IsKnown
-		networksBySSID[currentSSID] = current
+func mergeNetworks(visible []wifi.Network, knownSSIDs map[string]bool, currentSSID string) []wifi.Network {
+	networksByKey := make(map[darwinNetworkKey]wifi.Network, len(visible)+len(knownSSIDs)+1)
+	variantCount := make(map[string]int, len(visible))
+	for _, network := range visible {
+		variantCount[network.SSID]++
+	}
+	currentSSIDVisible := false
+	visibleSSIDs := make(map[string]bool, len(visible))
+	for _, network := range cloneNetworks(visible) {
+		// networksetup reports current and preferred networks by SSID only.
+		// Do not apply that metadata to an arbitrary security variant when the
+		// scan found more than one; doing so could mark an open evil twin known.
+		unambiguous := variantCount[network.SSID] == 1
+		network.IsActive = unambiguous && network.SSID == currentSSID
+		network.IsKnown = unambiguous && knownSSIDs[network.SSID]
+		network.AutoConnect = network.IsKnown
+		key := darwinNetworkKey{ssid: network.SSID, security: network.Security}
+		networksByKey[key] = network
+		visibleSSIDs[network.SSID] = true
+		currentSSIDVisible = currentSSIDVisible || network.SSID == currentSSID
+	}
+	if currentSSID != "" && !currentSSIDVisible {
+		key := darwinNetworkKey{ssid: currentSSID, security: wifi.SecurityUnknown}
+		networksByKey[key] = wifi.Network{
+			SSID:        currentSSID,
+			IsActive:    true,
+			IsVisible:   true,
+			IsKnown:     knownSSIDs[currentSSID],
+			AutoConnect: knownSSIDs[currentSSID],
+			Security:    wifi.SecurityUnknown,
+		}
+		visibleSSIDs[currentSSID] = true
 	}
 
 	for ssid := range knownSSIDs {
-		if _, ok := networksBySSID[ssid]; !ok {
-			networksBySSID[ssid] = wifi.Network{
+		if !visibleSSIDs[ssid] {
+			key := darwinNetworkKey{ssid: ssid, security: wifi.SecurityUnknown}
+			networksByKey[key] = wifi.Network{
 				SSID:        ssid,
 				IsKnown:     true,
 				AutoConnect: true,
+				Security:    wifi.SecurityUnknown,
 			}
 		}
 	}
-	return sortedNetworks(networksBySSID)
+	return sortedNetworks(networksByKey)
 }
 
-func sortedNetworks(networksBySSID map[string]wifi.Network) []wifi.Network {
-	networks := make([]wifi.Network, 0, len(networksBySSID))
-	for _, network := range networksBySSID {
+type darwinNetworkKey struct {
+	ssid     string
+	security wifi.SecurityType
+}
+
+func (b *Backend) cachedNetworks() []wifi.Network {
+	b.cacheMu.RLock()
+	defer b.cacheMu.RUnlock()
+	return cloneNetworks(b.lastVisible)
+}
+
+func (b *Backend) storeNetworks(networks []wifi.Network) {
+	b.cacheMu.Lock()
+	b.lastVisible = cloneNetworks(networks)
+	b.cacheMu.Unlock()
+}
+
+func cloneNetworks(networks []wifi.Network) []wifi.Network {
+	cloned := make([]wifi.Network, len(networks))
+	for i, network := range networks {
+		cloned[i] = network
+		cloned[i].AccessPoints = append([]wifi.AccessPoint(nil), network.AccessPoints...)
+	}
+	return cloned
+}
+
+func sortedNetworks(networksByKey map[darwinNetworkKey]wifi.Network) []wifi.Network {
+	networks := make([]wifi.Network, 0, len(networksByKey))
+	for _, network := range networksByKey {
 		networks = append(networks, network)
 	}
 	wifi.SortNetworks(networks)
 	return networks
-}
-
-// parseSystemProfilerOutput parses the output of `system_profiler SPAirPortDataType`
-// to extract visible Wi-Fi networks with their signal strength and security.
-func parseSystemProfilerOutput(output string) []scannedNetwork {
-	var networks []scannedNetwork
-	processedSSIDs := make(map[string]bool)
-
-	scanner := bufio.NewScanner(strings.NewReader(output))
-
-	inCurrentNetwork := false
-	inOtherNetworks := false
-	var currentNetwork *scannedNetwork
-
-	signalRe := regexp.MustCompile(`Signal / Noise:\s*(-?\d+)\s*dBm`)
-	securityRe := regexp.MustCompile(`Security:\s*(.+)`)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Detect section headers
-		if strings.Contains(line, "Current Network Information:") {
-			inCurrentNetwork = true
-			inOtherNetworks = false
-			continue
-		}
-		if strings.Contains(line, "Other Local Wi-Fi Networks:") {
-			inCurrentNetwork = false
-			inOtherNetworks = true
-			continue
-		}
-
-		// Stop parsing if we hit another interface (like awdl0)
-		if strings.HasPrefix(strings.TrimSpace(line), "awdl") {
-			break
-		}
-
-		if !inCurrentNetwork && !inOtherNetworks {
-			continue
-		}
-
-		trimmed := strings.TrimSpace(line)
-
-		// Network name detection: lines that end with ":" and have specific indentation
-		// In system_profiler output, network names are at a specific indent level
-		leadingSpaces := len(line) - len(strings.TrimLeft(line, " "))
-
-		// Network names are at 12-space indent (under Current/Other sections)
-		if leadingSpaces == 12 && strings.HasSuffix(trimmed, ":") && !strings.Contains(trimmed, ": ") {
-			// Save previous network if exists
-			if currentNetwork != nil && currentNetwork.ssid != "" {
-				if !processedSSIDs[currentNetwork.ssid] {
-					networks = append(networks, *currentNetwork)
-					processedSSIDs[currentNetwork.ssid] = true
-				} else if currentNetwork.rssi != 0 {
-					// Update existing entry if this one has signal strength
-					for i := range networks {
-						if networks[i].ssid == currentNetwork.ssid && networks[i].rssi == 0 {
-							networks[i].rssi = currentNetwork.rssi
-							break
-						}
-					}
-				}
-			}
-
-			ssid := strings.TrimSuffix(trimmed, ":")
-			currentNetwork = &scannedNetwork{
-				ssid:     ssid,
-				isActive: inCurrentNetwork,
-				rssi:     0,
-				security: wifi.SecurityOpen,
-			}
-			continue
-		}
-
-		// Parse properties of current network
-		if currentNetwork != nil {
-			if matches := signalRe.FindStringSubmatch(line); len(matches) > 1 {
-				rssi, _ := strconv.Atoi(matches[1])
-				currentNetwork.rssi = rssi
-			}
-			if matches := securityRe.FindStringSubmatch(line); len(matches) > 1 {
-				secStr := strings.TrimSpace(matches[1])
-				currentNetwork.security = parseSecurityType(secStr)
-			}
-		}
-	}
-
-	// Don't forget the last network
-	if currentNetwork != nil && currentNetwork.ssid != "" {
-		if !processedSSIDs[currentNetwork.ssid] {
-			networks = append(networks, *currentNetwork)
-		} else if currentNetwork.rssi != 0 {
-			for i := range networks {
-				if networks[i].ssid == currentNetwork.ssid && networks[i].rssi == 0 {
-					networks[i].rssi = currentNetwork.rssi
-					break
-				}
-			}
-		}
-	}
-
-	return networks
-}
-
-func parseSecurityType(s string) wifi.SecurityType {
-	s = strings.ToLower(s)
-	if strings.Contains(s, "wpa3") || strings.Contains(s, "wpa2") || strings.Contains(s, "wpa") {
-		return wifi.SecurityWPA
-	}
-	if strings.Contains(s, "wep") {
-		return wifi.SecurityWEP
-	}
-	return wifi.SecurityOpen
 }
 
 func rssiToStrength(rssi int) uint8 {

--- a/wifi/darwin/darwin_logic.go
+++ b/wifi/darwin/darwin_logic.go
@@ -3,6 +3,7 @@ package darwin
 import (
 	"bufio"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,11 +11,181 @@ import (
 	"github.com/shazow/wifitui/wifi"
 )
 
+// runWithOutput wraps exec.Cmd to capture stderr and preserve its execution error.
+func runWithOutput(command *exec.Cmd) ([]byte, error) {
+	var stderr strings.Builder
+	command.Stderr = &stderr
+	out, err := command.Output()
+	if err != nil {
+		return out, fmt.Errorf("failed to run command: %s: %w: %s", command.String(), err, stderr.String())
+	}
+	return out, nil
+}
+
+// runOnly wraps exec.Cmd for commands where stdout is not used.
+func runOnly(command *exec.Cmd) error {
+	var stderr strings.Builder
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("failed to run command: %s: %w: %s", command.String(), err, stderr.String())
+	}
+	return nil
+}
+
 type scannedNetwork struct {
 	ssid     string
 	security wifi.SecurityType
 	rssi     int
 	isActive bool
+}
+
+type outputRunner func(name string, args ...string) ([]byte, error)
+
+var currentNetworkRE = regexp.MustCompile(`Current Wi-Fi Network: (.+)`)
+
+// listNetworks contains the command orchestration separately from the
+// Darwin-specific exec implementation so its behavior can be tested on any OS.
+func listNetworks(run outputRunner, device string, scan wifi.ScanMode) (wifi.NetworksResult, error) {
+	out, err := run("networksetup", "-getairportpower", device)
+	if err != nil {
+		return wifi.NetworksResult{}, fmt.Errorf("failed to get wireless power: %w", err)
+	}
+	if !strings.Contains(string(out), ": On") {
+		return wifi.NetworksResult{}, wifi.ErrWirelessDisabled
+	}
+
+	// The association query is best effort: preferred networks and profiler
+	// results are still useful without it. If fallback is also needed, preserve
+	// both failures in ScanError because the missing association degrades it.
+	currentOut, currentErr := run("networksetup", "-getairportnetwork", device)
+	currentSSID := ""
+	if currentErr == nil {
+		matches := currentNetworkRE.FindStringSubmatch(string(currentOut))
+		if len(matches) > 1 {
+			currentSSID = strings.TrimSpace(matches[1])
+		}
+	}
+
+	preferredOut, err := run("networksetup", "-listpreferredwirelessnetworks", device)
+	if err != nil {
+		return wifi.NetworksResult{}, fmt.Errorf("failed to list preferred networks: %w: %w", wifi.ErrOperationFailed, err)
+	}
+	knownSSIDs := parsePreferredNetworks(string(preferredOut))
+
+	if scan == wifi.ScanNever {
+		return wifi.NetworksResult{Networks: fallbackNetworks(knownSSIDs, currentSSID)}, nil
+	}
+
+	// TODO: Use CoreWLAN for a true scan and retain its last successful snapshot.
+	// system_profiler cannot distinguish ScanAuto from ScanForce and does not
+	// guarantee that collecting its report initiates a new wireless scan.
+	profilerOut, err := run("system_profiler", "SPAirPortDataType")
+	if err != nil {
+		cause := err
+		if currentErr != nil {
+			cause = fmt.Errorf("system report failed: %w; current network query also failed: %w", err, currentErr)
+		}
+		return wifi.NetworksResult{
+			Networks: fallbackNetworks(knownSSIDs, currentSSID),
+			IsCached: true,
+			ScanError: &wifi.ScanFailure{
+				Backend: "macOS",
+				Stage:   wifi.ScanStageRequest,
+				Device:  device,
+				Cause:   cause,
+			},
+		}, nil
+	}
+
+	return wifi.NetworksResult{Networks: aggregateNetworks(
+		parseSystemProfilerOutput(string(profilerOut)), knownSSIDs, currentSSID,
+	)}, nil
+}
+
+func parsePreferredNetworks(output string) map[string]bool {
+	knownSSIDs := make(map[string]bool)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && !strings.HasPrefix(line, "Preferred") {
+			knownSSIDs[line] = true
+		}
+	}
+	return knownSSIDs
+}
+
+func fallbackNetworks(knownSSIDs map[string]bool, currentSSID string) []wifi.Network {
+	networksBySSID := make(map[string]wifi.Network, len(knownSSIDs)+1)
+	for ssid := range knownSSIDs {
+		networksBySSID[ssid] = wifi.Network{
+			SSID:        ssid,
+			IsKnown:     true,
+			AutoConnect: true,
+		}
+	}
+	if currentSSID != "" {
+		current := networksBySSID[currentSSID]
+		current.SSID = currentSSID
+		current.IsActive = true
+		current.IsVisible = true
+		networksBySSID[currentSSID] = current
+	}
+	return sortedNetworks(networksBySSID)
+}
+
+func aggregateNetworks(scanned []scannedNetwork, knownSSIDs map[string]bool, currentSSID string) []wifi.Network {
+	networksBySSID := make(map[string]wifi.Network, len(scanned)+len(knownSSIDs)+1)
+	for _, network := range scanned {
+		known := knownSSIDs[network.ssid]
+		active := network.isActive || network.ssid == currentSSID
+		accessPoint := wifi.AccessPoint{Strength: rssiToStrength(network.rssi)}
+		if existing, ok := networksBySSID[network.ssid]; ok {
+			existing.AccessPoints = append(existing.AccessPoints, accessPoint)
+			existing.IsActive = existing.IsActive || active
+			networksBySSID[network.ssid] = existing
+			continue
+		}
+		networksBySSID[network.ssid] = wifi.Network{
+			SSID:         network.ssid,
+			IsActive:     active,
+			IsKnown:      known,
+			IsVisible:    true,
+			AccessPoints: []wifi.AccessPoint{accessPoint},
+			IsSecure:     network.security != wifi.SecurityOpen,
+			Security:     network.security,
+			AutoConnect:  known,
+		}
+	}
+
+	if currentSSID != "" {
+		current := networksBySSID[currentSSID]
+		current.SSID = currentSSID
+		current.IsActive = true
+		current.IsVisible = true
+		current.IsKnown = knownSSIDs[currentSSID]
+		current.AutoConnect = current.IsKnown
+		networksBySSID[currentSSID] = current
+	}
+
+	for ssid := range knownSSIDs {
+		if _, ok := networksBySSID[ssid]; !ok {
+			networksBySSID[ssid] = wifi.Network{
+				SSID:        ssid,
+				IsKnown:     true,
+				AutoConnect: true,
+			}
+		}
+	}
+	return sortedNetworks(networksBySSID)
+}
+
+func sortedNetworks(networksBySSID map[string]wifi.Network) []wifi.Network {
+	networks := make([]wifi.Network, 0, len(networksBySSID))
+	for _, network := range networksBySSID {
+		networks = append(networks, network)
+	}
+	wifi.SortNetworks(networks)
+	return networks
 }
 
 // parseSystemProfilerOutput parses the output of `system_profiler SPAirPortDataType`

--- a/wifi/darwin/darwin_logic.go
+++ b/wifi/darwin/darwin_logic.go
@@ -219,7 +219,6 @@ func parsePreferredNetworks(output string) map[string]bool {
 func (b *Backend) scanFallback(cached []wifi.Network, knownSSIDs map[string]bool, currentSSID string, stage wifi.ScanStage, cause error) wifi.NetworksResult {
 	return wifi.NetworksResult{
 		Networks: mergeNetworks(cached, knownSSIDs, currentSSID),
-		IsCached: true,
 		ScanError: &wifi.ScanFailure{
 			Backend: "macOS",
 			Stage:   stage,

--- a/wifi/darwin/darwin_test.go
+++ b/wifi/darwin/darwin_test.go
@@ -1,12 +1,13 @@
 package darwin
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/shazow/wifitui/wifi"
@@ -77,12 +78,20 @@ func baseCommandResults() map[string]commandResult {
 	}
 }
 
-func TestListNetworksScanNeverSkipsProfiler(t *testing.T) {
+func TestListNetworksScanNeverSkipsScan(t *testing.T) {
 	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			t.Fatal("ScanNever invoked the scanner")
+			return nil, nil
+		},
+	}
 
-	result, err := listNetworks(runner.run, "en0", wifi.ScanNever)
+	result, err := backend.ListNetworks(wifi.ScanNever)
 	if err != nil {
-		t.Fatalf("listNetworks returned an error: %v", err)
+		t.Fatalf("ListNetworks returned an error: %v", err)
 	}
 	if result.ScanError != nil {
 		t.Fatalf("ScanNever returned a scan error: %v", result.ScanError)
@@ -90,8 +99,8 @@ func TestListNetworksScanNeverSkipsProfiler(t *testing.T) {
 	if result.IsCached {
 		t.Fatal("ScanNever marked the current network list as cached")
 	}
-	if runner.unexpected || slices.Contains(runner.commands, "system_profiler SPAirPortDataType") {
-		t.Fatal("ScanNever invoked system_profiler")
+	if runner.unexpected {
+		t.Fatal("ScanNever invoked an unexpected command")
 	}
 	if len(result.Networks) != 2 {
 		t.Fatalf("listNetworks returned %d networks, want 2: %#v", len(result.Networks), result.Networks)
@@ -106,34 +115,35 @@ func TestListNetworksScanNeverSkipsProfiler(t *testing.T) {
 	}
 }
 
-func TestListNetworksScanModesRunProfiler(t *testing.T) {
-	const profilerOutput = `Wi-Fi:
-      Interfaces:
-        en0:
-          Current Network Information:
-            Guest:
-              Security: WPA2 Personal
-              Signal / Noise: -55 dBm / -95 dBm
-          Other Local Wi-Fi Networks:
-            Home:
-              Security: WPA2 Personal
-              Signal / Noise: -70 dBm / -90 dBm`
-
+func TestListNetworksScanModesRunScanner(t *testing.T) {
 	for _, scan := range []wifi.ScanMode{wifi.ScanAuto, wifi.ScanForce} {
 		t.Run(fmt.Sprintf("mode_%d", scan), func(t *testing.T) {
-			results := baseCommandResults()
-			results["system_profiler SPAirPortDataType"] = commandResult{output: profilerOutput}
-			runner := &fakeOutputRunner{t: t, results: results}
+			runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+			scanCalls := 0
+			backend := &Backend{
+				WifiInterface: "en0",
+				runOutput:     runner.run,
+				scanNetworks: func(device string) ([]scannedNetwork, error) {
+					scanCalls++
+					if device != "en0" {
+						t.Fatalf("scan device = %q, want en0", device)
+					}
+					return []scannedNetwork{
+						{ssid: "Guest", bssid: "00:11:22:33:44:55", security: wifi.SecurityWPA, rssi: -55},
+						{ssid: "Home", bssid: "00:11:22:33:44:66", security: wifi.SecurityWPA, rssi: -70},
+					}, nil
+				},
+			}
 
-			result, err := listNetworks(runner.run, "en0", scan)
+			result, err := backend.ListNetworks(scan)
 			if err != nil {
-				t.Fatalf("listNetworks returned an error: %v", err)
+				t.Fatalf("ListNetworks returned an error: %v", err)
 			}
 			if result.ScanError != nil || result.IsCached {
 				t.Fatalf("successful report returned scan fallback metadata: %#v", result)
 			}
-			if got := countCommand(runner.commands, "system_profiler SPAirPortDataType"); got != 1 {
-				t.Fatalf("system_profiler call count = %d, want 1", got)
+			if scanCalls != 1 {
+				t.Fatalf("scanner call count = %d, want 1", scanCalls)
 			}
 			if len(result.Networks) != 2 || result.Networks[0].SSID != "Guest" || !result.Networks[0].IsActive {
 				t.Fatalf("listNetworks returned unexpected networks: %#v", result.Networks)
@@ -142,21 +152,26 @@ func TestListNetworksScanModesRunProfiler(t *testing.T) {
 	}
 }
 
-func TestListNetworksProfilerFailureReturnsVisibleCurrentNetwork(t *testing.T) {
-	profilerErr := errors.New("profiler failed")
-	results := baseCommandResults()
-	results["system_profiler SPAirPortDataType"] = commandResult{err: profilerErr}
-	runner := &fakeOutputRunner{t: t, results: results}
+func TestListNetworksScanFailureReturnsVisibleCurrentNetwork(t *testing.T) {
+	scanErr := errors.New("CoreWLAN failed")
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, scanErr
+		},
+	}
 
-	result, err := listNetworks(runner.run, "en0", wifi.ScanForce)
+	result, err := backend.ListNetworks(wifi.ScanForce)
 	if err != nil {
 		t.Fatalf("listNetworks returned a fatal error: %v", err)
 	}
 	if !result.IsCached {
 		t.Fatal("scan fallback did not set IsCached")
 	}
-	if !errors.Is(result.ScanError, profilerErr) {
-		t.Fatalf("ScanError = %v, want wrapped profiler error", result.ScanError)
+	if !errors.Is(result.ScanError, scanErr) {
+		t.Fatalf("ScanError = %v, want wrapped CoreWLAN error", result.ScanError)
 	}
 	var failure *wifi.ScanFailure
 	if !errors.As(result.ScanError, &failure) {
@@ -170,19 +185,25 @@ func TestListNetworksProfilerFailureReturnsVisibleCurrentNetwork(t *testing.T) {
 	}
 }
 
-func TestListNetworksProfilerAndCurrentNetworkFailuresArePreserved(t *testing.T) {
+func TestListNetworksScanAndCurrentNetworkFailuresArePreserved(t *testing.T) {
 	currentErr := errors.New("current network failed")
-	profilerErr := errors.New("profiler failed")
+	scanErr := errors.New("CoreWLAN failed")
 	results := baseCommandResults()
 	results["networksetup -getairportnetwork en0"] = commandResult{err: currentErr}
-	results["system_profiler SPAirPortDataType"] = commandResult{err: profilerErr}
 	runner := &fakeOutputRunner{t: t, results: results}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, scanErr
+		},
+	}
 
-	result, err := listNetworks(runner.run, "en0", wifi.ScanAuto)
+	result, err := backend.ListNetworks(wifi.ScanAuto)
 	if err != nil {
 		t.Fatalf("listNetworks returned a fatal error: %v", err)
 	}
-	if !errors.Is(result.ScanError, profilerErr) || !errors.Is(result.ScanError, currentErr) {
+	if !errors.Is(result.ScanError, scanErr) || !errors.Is(result.ScanError, currentErr) {
 		t.Fatalf("ScanError = %v, want both command errors preserved", result.ScanError)
 	}
 	if len(result.Networks) != 1 || result.Networks[0].SSID != "Home" || result.Networks[0].IsVisible {
@@ -190,14 +211,270 @@ func TestListNetworksProfilerAndCurrentNetworkFailuresArePreserved(t *testing.T)
 	}
 }
 
-func countCommand(commands []string, want string) int {
-	count := 0
-	for _, command := range commands {
-		if command == want {
-			count++
+func TestListNetworksRetainsSuccessfulVisibleSnapshot(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return []scannedNetwork{
+				{ssid: "Guest", security: wifi.SecurityWPA, rssi: -50},
+				{ssid: "Cafe", security: wifi.SecurityOpen, rssi: -65},
+			}, nil
+		},
+	}
+
+	scanned, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil || scanned.ScanError != nil {
+		t.Fatalf("initial scan = %#v, %v", scanned, err)
+	}
+	for i := range scanned.Networks {
+		if scanned.Networks[i].SSID == "Cafe" {
+			scanned.Networks[i].AccessPoints[0].Strength = 1
 		}
 	}
-	return count
+
+	cached, err := backend.ListNetworks(wifi.ScanNever)
+	if err != nil {
+		t.Fatalf("ScanNever returned an error: %v", err)
+	}
+	cafe, ok := networkBySSID(cached.Networks, "Cafe")
+	if !ok || !cafe.IsVisible || cafe.IsKnown || cafe.Strength() != 70 {
+		t.Fatalf("cached Cafe = %#v, %t; want independent visible snapshot at 70%%", cafe, ok)
+	}
+}
+
+func TestListNetworksFailedScanUsesRetainedSnapshot(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	fail := false
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			if fail {
+				return nil, errors.New("later scan failed")
+			}
+			return []scannedNetwork{{ssid: "Cafe", security: wifi.SecurityOpen, rssi: -65}}, nil
+		},
+	}
+	if _, err := backend.ListNetworks(wifi.ScanAuto); err != nil {
+		t.Fatalf("initial scan failed: %v", err)
+	}
+	fail = true
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("failed scan returned fatal error: %v", err)
+	}
+	if result.ScanError == nil || !result.IsCached {
+		t.Fatalf("failed scan metadata = %#v", result)
+	}
+	if cafe, ok := networkBySSID(result.Networks, "Cafe"); !ok || !cafe.IsVisible {
+		t.Fatalf("failed scan discarded cached Cafe: %#v", result.Networks)
+	}
+}
+
+func TestBackendVisibleSnapshotIsConcurrentSafe(t *testing.T) {
+	backend := &Backend{}
+	var workers sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		workers.Add(1)
+		go func(worker int) {
+			defer workers.Done()
+			for iteration := 0; iteration < 100; iteration++ {
+				backend.storeNetworks([]wifi.Network{{
+					SSID:         fmt.Sprintf("network-%d", worker),
+					IsVisible:    true,
+					AccessPoints: []wifi.AccessPoint{{Strength: uint8(iteration)}},
+				}})
+				cached := backend.cachedNetworks()
+				if len(cached) != 1 {
+					t.Errorf("cached network count = %d, want 1", len(cached))
+					return
+				}
+			}
+		}(worker)
+	}
+	workers.Wait()
+}
+
+func TestListNetworksEmptyScanClearsVisibleSnapshot(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		lastVisible: []wifi.Network{{
+			SSID:      "Stale Cafe",
+			IsVisible: true,
+		}},
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, nil
+		},
+	}
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks returned fatal error: %v", err)
+	}
+	if result.ScanError != nil || result.IsCached {
+		t.Fatalf("empty successful scan returned fallback metadata: %#v", result)
+	}
+	if _, ok := networkBySSID(result.Networks, "Stale Cafe"); ok {
+		t.Fatalf("empty successful scan retained stale visible network: %#v", result.Networks)
+	}
+}
+
+func TestListNetworksUnsupportedScanIsTypedFailure(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, wifi.ErrNotSupported
+		},
+	}
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks returned fatal error: %v", err)
+	}
+	var failure *wifi.ScanFailure
+	if !errors.As(result.ScanError, &failure) || !errors.Is(result.ScanError, wifi.ErrNotSupported) {
+		t.Fatalf("ScanError = %#v, want typed unsupported ScanFailure", result.ScanError)
+	}
+}
+
+func TestListNetworksTimeoutIsCompletionFailure(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, wifi.ErrScanTimeout
+		},
+	}
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks returned fatal error: %v", err)
+	}
+	var failure *wifi.ScanFailure
+	if !errors.As(result.ScanError, &failure) || failure.Stage != wifi.ScanStageCompletion {
+		t.Fatalf("ScanError = %#v, want completion-stage timeout", result.ScanError)
+	}
+}
+
+func TestVisibleNetworksKeepsSecurityVariantsSeparate(t *testing.T) {
+	networks := visibleNetworks([]scannedNetwork{
+		{ssid: "Cafe", bssid: "00:11:22:33:44:55", security: wifi.SecurityOpen, rssi: -60},
+		{ssid: "Cafe", bssid: "00:11:22:33:44:66", security: wifi.SecurityWPA, rssi: -50},
+	})
+
+	if len(networks) != 2 {
+		t.Fatalf("visibleNetworks returned %d networks, want separate open and WPA entries: %#v", len(networks), networks)
+	}
+	seen := make(map[wifi.SecurityType]wifi.Network, len(networks))
+	for _, network := range networks {
+		seen[network.Security] = network
+	}
+	if seen[wifi.SecurityOpen].IsSecure || !seen[wifi.SecurityWPA].IsSecure {
+		t.Fatalf("security variants = %#v, want open and secure WPA entries", seen)
+	}
+	if len(seen[wifi.SecurityOpen].AccessPoints) != 1 || len(seen[wifi.SecurityWPA].AccessPoints) != 1 {
+		t.Fatalf("security variants merged access points: %#v", seen)
+	}
+}
+
+func TestMergeNetworksDoesNotTrustAmbiguousSSIDMetadata(t *testing.T) {
+	visible := visibleNetworks([]scannedNetwork{
+		{ssid: "Cafe", bssid: "00:11:22:33:44:55", security: wifi.SecurityOpen, rssi: -60},
+		{ssid: "Cafe", bssid: "00:11:22:33:44:66", security: wifi.SecurityWPA, rssi: -50},
+	})
+	networks := mergeNetworks(visible, map[string]bool{"Cafe": true}, "Cafe")
+
+	if len(networks) != 2 {
+		t.Fatalf("mergeNetworks returned %d networks, want 2 security variants: %#v", len(networks), networks)
+	}
+	for _, network := range networks {
+		if network.IsKnown || network.IsActive || network.AutoConnect {
+			t.Fatalf("ambiguous security variant received SSID-only metadata: %#v", network)
+		}
+	}
+}
+
+func TestDecodeCoreWLANScan(t *testing.T) {
+	output := []byte(`[
+		{"ssid":"Cafe","bssid":"00:11:22:33:44:55","security":"open","rssi":-65,"frequency":2412},
+		{"ssid":"Home","bssid":"00:11:22:33:44:66","security":"wpa","rssi":-50,"frequency":5180}
+	]`)
+	networks, err := decodeCoreWLANScan(output)
+	if err != nil {
+		t.Fatalf("decodeCoreWLANScan returned error: %v", err)
+	}
+	if len(networks) != 2 || networks[0].ssid != "Cafe" || networks[0].security != wifi.SecurityOpen || networks[1].frequency != 5180 {
+		t.Fatalf("decodeCoreWLANScan = %#v", networks)
+	}
+}
+
+func TestDecodeCoreWLANScanAllowsEmptyResults(t *testing.T) {
+	networks, err := decodeCoreWLANScan([]byte("[]"))
+	if err != nil || len(networks) != 0 {
+		t.Fatalf("decodeCoreWLANScan(empty set) = %#v, %v; want empty success", networks, err)
+	}
+}
+
+func TestDecodeCoreWLANScanRejectsUnusableResults(t *testing.T) {
+	for _, output := range []string{"", `[{"ssid":""}]`, "not json"} {
+		t.Run(output, func(t *testing.T) {
+			_, err := decodeCoreWLANScan([]byte(output))
+			if !errors.Is(err, wifi.ErrScanProtocol) {
+				t.Fatalf("decodeCoreWLANScan(%q) = %v, want ErrScanProtocol", output, err)
+			}
+		})
+	}
+}
+
+func TestDecodeCoreWLANScanPreservesJSONError(t *testing.T) {
+	_, err := decodeCoreWLANScan([]byte("["))
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("decodeCoreWLANScan error = %v, want wrapped *json.SyntaxError", err)
+	}
+}
+
+func TestCoreWLANStatusErrorClassifiesKnownFailures(t *testing.T) {
+	tests := []struct {
+		status int
+		want   error
+	}{
+		{coreWLANStatusDeviceUnavailable, wifi.ErrScanDeviceUnavailable},
+		{coreWLANStatusProtocol, wifi.ErrScanProtocol},
+		{coreWLANStatusPermissionDenied, wifi.ErrScanPermissionDenied},
+		{coreWLANStatusTimeout, wifi.ErrScanTimeout},
+		{coreWLANStatusUnsupported, wifi.ErrNotSupported},
+	}
+	for _, test := range tests {
+		err := coreWLANStatusError(test.status, "native detail")
+		if !errors.Is(err, test.want) || !strings.Contains(err.Error(), "native detail") {
+			t.Fatalf("coreWLANStatusError(%d) = %v, want native detail wrapping %v", test.status, err, test.want)
+		}
+	}
+}
+
+func TestParsePreferredNetworksKeepsSSIDStartingWithPreferred(t *testing.T) {
+	known := parsePreferredNetworks("Preferred networks on en0:\n\tHome\n\tPreferred Cafe\n")
+	if !known["Home"] || !known["Preferred Cafe"] || len(known) != 2 {
+		t.Fatalf("parsePreferredNetworks = %#v", known)
+	}
+}
+
+func networkBySSID(networks []wifi.Network, ssid string) (wifi.Network, bool) {
+	for _, network := range networks {
+		if network.SSID == ssid {
+			return network, true
+		}
+	}
+	return wifi.Network{}, false
 }
 
 func TestFindWifiDevice(t *testing.T) {
@@ -219,96 +496,6 @@ Ethernet Address: a1:b2:c3:d4:e5:f8`
 	}
 	if device != "en0" {
 		t.Fatalf(`findWifiDevice returned "%s", want "en0"`, device)
-	}
-}
-
-func TestParseSystemProfilerOutput(t *testing.T) {
-	mockedOutput := `Wi-Fi:
-
-      Software Versions:
-          CoreWLAN: 16.0 (1657)
-      Interfaces:
-        en0:
-          Card Type: Wi-Fi
-          Status: Connected
-          Current Network Information:
-            MyHomeNetwork:
-              PHY Mode: 802.11ac
-              Channel: 36 (5GHz, 80MHz)
-              Network Type: Infrastructure
-              Security: WPA2 Personal
-              Signal / Noise: -55 dBm / -95 dBm
-              Transmit Rate: 866
-          Other Local Wi-Fi Networks:
-            NeighborWiFi:
-              PHY Mode: 802.11n
-              Channel: 6 (2GHz, 20MHz)
-              Network Type: Infrastructure
-              Security: WPA2 Personal
-              Signal / Noise: -75 dBm / -90 dBm
-            OpenCafe:
-              PHY Mode: 802.11g
-              Channel: 11 (2GHz, 20MHz)
-              Network Type: Infrastructure
-              Security: Open
-        awdl0:
-          MAC Address: 00:11:22:33:44:55`
-
-	networks := parseSystemProfilerOutput(mockedOutput)
-
-	if len(networks) != 3 {
-		t.Fatalf("expected 3 networks, got %d", len(networks))
-	}
-
-	// Check active network
-	found := false
-	for _, n := range networks {
-		if n.ssid == "MyHomeNetwork" {
-			found = true
-			if !n.isActive {
-				t.Error("MyHomeNetwork should be marked as active")
-			}
-			if n.rssi != -55 {
-				t.Errorf("MyHomeNetwork rssi should be -55, got %d", n.rssi)
-			}
-			if n.security != wifi.SecurityWPA {
-				t.Errorf("MyHomeNetwork security should be WPA, got %v", n.security)
-			}
-		}
-	}
-	if !found {
-		t.Error("MyHomeNetwork not found in parsed networks")
-	}
-
-	// Check neighbor network
-	found = false
-	for _, n := range networks {
-		if n.ssid == "NeighborWiFi" {
-			found = true
-			if n.isActive {
-				t.Error("NeighborWiFi should not be marked as active")
-			}
-			if n.rssi != -75 {
-				t.Errorf("NeighborWiFi rssi should be -75, got %d", n.rssi)
-			}
-		}
-	}
-	if !found {
-		t.Error("NeighborWiFi not found in parsed networks")
-	}
-
-	// Check open network
-	found = false
-	for _, n := range networks {
-		if n.ssid == "OpenCafe" {
-			found = true
-			if n.security != wifi.SecurityOpen {
-				t.Errorf("OpenCafe security should be Open, got %v", n.security)
-			}
-		}
-	}
-	if !found {
-		t.Error("OpenCafe not found in parsed networks")
 	}
 }
 

--- a/wifi/darwin/darwin_test.go
+++ b/wifi/darwin/darwin_test.go
@@ -1,10 +1,204 @@
 package darwin
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/shazow/wifitui/wifi"
 )
+
+func TestRunWithOutputPreservesExitErrorAndStderr(t *testing.T) {
+	command := exec.Command(os.Args[0], "-test.run=TestCommandHelperProcess")
+	command.Env = append(os.Environ(), "WIFITUI_TEST_COMMAND_HELPER=1")
+
+	out, err := runWithOutput(command)
+	if string(out) != "partial output" {
+		t.Fatalf("runWithOutput output = %q, want partial output", out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 7 {
+		t.Fatalf("runWithOutput error = %v, want wrapped exit status 7", err)
+	}
+	if !strings.Contains(err.Error(), "diagnostic detail") {
+		t.Fatalf("runWithOutput error = %q, want captured stderr", err)
+	}
+}
+
+func TestCommandHelperProcess(t *testing.T) {
+	if os.Getenv("WIFITUI_TEST_COMMAND_HELPER") != "1" {
+		return
+	}
+	_, _ = fmt.Fprint(os.Stdout, "partial output")
+	_, _ = fmt.Fprint(os.Stderr, "diagnostic detail")
+	os.Exit(7)
+}
+
+type commandResult struct {
+	output string
+	err    error
+}
+
+type fakeOutputRunner struct {
+	t          *testing.T
+	results    map[string]commandResult
+	commands   []string
+	unexpected bool
+}
+
+func (r *fakeOutputRunner) run(name string, args ...string) ([]byte, error) {
+	r.t.Helper()
+	command := strings.Join(append([]string{name}, args...), " ")
+	r.commands = append(r.commands, command)
+	result, ok := r.results[command]
+	if !ok {
+		r.unexpected = true
+		r.t.Errorf("unexpected command: %s", command)
+		return nil, fmt.Errorf("unexpected command: %s", command)
+	}
+	return []byte(result.output), result.err
+}
+
+func baseCommandResults() map[string]commandResult {
+	return map[string]commandResult{
+		"networksetup -getairportpower en0": {
+			output: "Wi-Fi Power (en0): On\n",
+		},
+		"networksetup -getairportnetwork en0": {
+			output: "Current Wi-Fi Network: Guest\n",
+		},
+		"networksetup -listpreferredwirelessnetworks en0": {
+			output: "Preferred networks on en0:\n\tHome\n",
+		},
+	}
+}
+
+func TestListNetworksScanNeverSkipsProfiler(t *testing.T) {
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+
+	result, err := listNetworks(runner.run, "en0", wifi.ScanNever)
+	if err != nil {
+		t.Fatalf("listNetworks returned an error: %v", err)
+	}
+	if result.ScanError != nil {
+		t.Fatalf("ScanNever returned a scan error: %v", result.ScanError)
+	}
+	if result.IsCached {
+		t.Fatal("ScanNever marked the current network list as cached")
+	}
+	if runner.unexpected || slices.Contains(runner.commands, "system_profiler SPAirPortDataType") {
+		t.Fatal("ScanNever invoked system_profiler")
+	}
+	if len(result.Networks) != 2 {
+		t.Fatalf("listNetworks returned %d networks, want 2: %#v", len(result.Networks), result.Networks)
+	}
+	current := result.Networks[0]
+	if current.SSID != "Guest" || !current.IsActive || !current.IsVisible || current.IsKnown {
+		t.Fatalf("current non-preferred network = %#v, want active, visible, and unknown Guest", current)
+	}
+	known := result.Networks[1]
+	if known.SSID != "Home" || known.IsActive || known.IsVisible || !known.IsKnown || !known.AutoConnect {
+		t.Fatalf("preferred network = %#v, want non-visible known Home", known)
+	}
+}
+
+func TestListNetworksScanModesRunProfiler(t *testing.T) {
+	const profilerOutput = `Wi-Fi:
+      Interfaces:
+        en0:
+          Current Network Information:
+            Guest:
+              Security: WPA2 Personal
+              Signal / Noise: -55 dBm / -95 dBm
+          Other Local Wi-Fi Networks:
+            Home:
+              Security: WPA2 Personal
+              Signal / Noise: -70 dBm / -90 dBm`
+
+	for _, scan := range []wifi.ScanMode{wifi.ScanAuto, wifi.ScanForce} {
+		t.Run(fmt.Sprintf("mode_%d", scan), func(t *testing.T) {
+			results := baseCommandResults()
+			results["system_profiler SPAirPortDataType"] = commandResult{output: profilerOutput}
+			runner := &fakeOutputRunner{t: t, results: results}
+
+			result, err := listNetworks(runner.run, "en0", scan)
+			if err != nil {
+				t.Fatalf("listNetworks returned an error: %v", err)
+			}
+			if result.ScanError != nil || result.IsCached {
+				t.Fatalf("successful report returned scan fallback metadata: %#v", result)
+			}
+			if got := countCommand(runner.commands, "system_profiler SPAirPortDataType"); got != 1 {
+				t.Fatalf("system_profiler call count = %d, want 1", got)
+			}
+			if len(result.Networks) != 2 || result.Networks[0].SSID != "Guest" || !result.Networks[0].IsActive {
+				t.Fatalf("listNetworks returned unexpected networks: %#v", result.Networks)
+			}
+		})
+	}
+}
+
+func TestListNetworksProfilerFailureReturnsVisibleCurrentNetwork(t *testing.T) {
+	profilerErr := errors.New("profiler failed")
+	results := baseCommandResults()
+	results["system_profiler SPAirPortDataType"] = commandResult{err: profilerErr}
+	runner := &fakeOutputRunner{t: t, results: results}
+
+	result, err := listNetworks(runner.run, "en0", wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("listNetworks returned a fatal error: %v", err)
+	}
+	if !result.IsCached {
+		t.Fatal("scan fallback did not set IsCached")
+	}
+	if !errors.Is(result.ScanError, profilerErr) {
+		t.Fatalf("ScanError = %v, want wrapped profiler error", result.ScanError)
+	}
+	var failure *wifi.ScanFailure
+	if !errors.As(result.ScanError, &failure) {
+		t.Fatalf("ScanError type = %T, want *wifi.ScanFailure", result.ScanError)
+	}
+	if failure.Backend != "macOS" || failure.Stage != wifi.ScanStageRequest || failure.Device != "en0" {
+		t.Fatalf("ScanFailure = %#v, want macOS request failure on en0", failure)
+	}
+	if len(result.Networks) != 2 || result.Networks[0].SSID != "Guest" || !result.Networks[0].IsVisible {
+		t.Fatalf("fallback networks = %#v, want visible current Guest first", result.Networks)
+	}
+}
+
+func TestListNetworksProfilerAndCurrentNetworkFailuresArePreserved(t *testing.T) {
+	currentErr := errors.New("current network failed")
+	profilerErr := errors.New("profiler failed")
+	results := baseCommandResults()
+	results["networksetup -getairportnetwork en0"] = commandResult{err: currentErr}
+	results["system_profiler SPAirPortDataType"] = commandResult{err: profilerErr}
+	runner := &fakeOutputRunner{t: t, results: results}
+
+	result, err := listNetworks(runner.run, "en0", wifi.ScanAuto)
+	if err != nil {
+		t.Fatalf("listNetworks returned a fatal error: %v", err)
+	}
+	if !errors.Is(result.ScanError, profilerErr) || !errors.Is(result.ScanError, currentErr) {
+		t.Fatalf("ScanError = %v, want both command errors preserved", result.ScanError)
+	}
+	if len(result.Networks) != 1 || result.Networks[0].SSID != "Home" || result.Networks[0].IsVisible {
+		t.Fatalf("fallback networks = %#v, want only non-visible preferred Home", result.Networks)
+	}
+}
+
+func countCommand(commands []string, want string) int {
+	count := 0
+	for _, command := range commands {
+		if command == want {
+			count++
+		}
+	}
+	return count
+}
 
 func TestFindWifiDevice(t *testing.T) {
 	mockedOutput := `Hardware Port: Wi-Fi

--- a/wifi/darwin/darwin_test.go
+++ b/wifi/darwin/darwin_test.go
@@ -96,9 +96,6 @@ func TestListNetworksScanNeverSkipsScan(t *testing.T) {
 	if result.ScanError != nil {
 		t.Fatalf("ScanNever returned a scan error: %v", result.ScanError)
 	}
-	if result.IsCached {
-		t.Fatal("ScanNever marked the current network list as cached")
-	}
 	if runner.unexpected {
 		t.Fatal("ScanNever invoked an unexpected command")
 	}
@@ -139,7 +136,7 @@ func TestListNetworksScanModesRunScanner(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListNetworks returned an error: %v", err)
 			}
-			if result.ScanError != nil || result.IsCached {
+			if result.ScanError != nil {
 				t.Fatalf("successful report returned scan fallback metadata: %#v", result)
 			}
 			if scanCalls != 1 {
@@ -166,9 +163,6 @@ func TestListNetworksScanFailureReturnsVisibleCurrentNetwork(t *testing.T) {
 	result, err := backend.ListNetworks(wifi.ScanForce)
 	if err != nil {
 		t.Fatalf("listNetworks returned a fatal error: %v", err)
-	}
-	if !result.IsCached {
-		t.Fatal("scan fallback did not set IsCached")
 	}
 	if !errors.Is(result.ScanError, scanErr) {
 		t.Fatalf("ScanError = %v, want wrapped CoreWLAN error", result.ScanError)
@@ -266,7 +260,7 @@ func TestListNetworksFailedScanUsesRetainedSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed scan returned fatal error: %v", err)
 	}
-	if result.ScanError == nil || !result.IsCached {
+	if result.ScanError == nil {
 		t.Fatalf("failed scan metadata = %#v", result)
 	}
 	if cafe, ok := networkBySSID(result.Networks, "Cafe"); !ok || !cafe.IsVisible {
@@ -316,7 +310,7 @@ func TestListNetworksEmptyScanClearsVisibleSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListNetworks returned fatal error: %v", err)
 	}
-	if result.ScanError != nil || result.IsCached {
+	if result.ScanError != nil {
 		t.Fatalf("empty successful scan returned fallback metadata: %#v", result)
 	}
 	if _, ok := networkBySSID(result.Networks, "Stale Cafe"); ok {

--- a/wifi/errors.go
+++ b/wifi/errors.go
@@ -1,6 +1,9 @@
 package wifi
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrIncorrectPassphrase is returned when a connection fails due to an
 // incorrect passphrase.
@@ -26,3 +29,62 @@ var ErrAccessPointMismatch = errors.New("SSID or security mismatch")
 
 // ErrMissingPermission is returned when the user lacks necessary permissions.
 var ErrMissingPermission = errors.New("missing permission")
+
+// Scan failure classifications. Backends wrap these errors together with the
+// original platform error so callers can use errors.Is without losing the
+// underlying diagnostic information.
+var (
+	ErrScanDeviceUnavailable = errors.New("wireless device unavailable")
+	ErrScanPermissionDenied  = errors.New("Wi-Fi scan permission denied")
+	ErrScanAuthRequired      = errors.New("Wi-Fi scan authorization required")
+	ErrScanTimeout           = errors.New("scan timed out")
+	ErrScanProtocol          = errors.New("invalid scan response")
+)
+
+// ScanStage identifies the part of a scan operation that failed.
+type ScanStage string
+
+const (
+	ScanStageSetup      ScanStage = "setup"
+	ScanStageRequest    ScanStage = "request"
+	ScanStageCompletion ScanStage = "completion"
+)
+
+// ScanFailure adds backend and operation context to a non-fatal scan error.
+// Cause retains the original platform error and any wrapped classification.
+type ScanFailure struct {
+	Backend string
+	Stage   ScanStage
+	Device  string
+	Code    string
+	Cause   error
+}
+
+func (e *ScanFailure) Error() string {
+	operation := e.Backend
+	if e.Stage != "" {
+		if operation != "" {
+			operation += " "
+		}
+		operation += string(e.Stage)
+	}
+	if e.Device != "" {
+		if operation != "" {
+			operation += " "
+		}
+		operation += fmt.Sprintf("on %s", e.Device)
+	}
+
+	if e.Cause == nil {
+		return operation
+	}
+	if operation == "" {
+		return e.Cause.Error()
+	}
+	return fmt.Sprintf("%s: %v", operation, e.Cause)
+}
+
+// Unwrap exposes the classified platform error to errors.Is and errors.As.
+func (e *ScanFailure) Unwrap() error {
+	return e.Cause
+}

--- a/wifi/errors_test.go
+++ b/wifi/errors_test.go
@@ -1,0 +1,50 @@
+package wifi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type platformScanError struct {
+	code string
+}
+
+func (e *platformScanError) Error() string { return "scan rejected" }
+
+func TestScanFailurePreservesClassificationAndCause(t *testing.T) {
+	platformErr := &platformScanError{code: "not-allowed"}
+	cause := fmt.Errorf("%w: %w", ErrScanDeviceUnavailable, platformErr)
+	err := &ScanFailure{
+		Backend: "NetworkManager",
+		Stage:   ScanStageRequest,
+		Device:  "wlan0",
+		Code:    platformErr.code,
+		Cause:   cause,
+	}
+
+	if !errors.Is(err, ErrScanDeviceUnavailable) {
+		t.Fatal("errors.Is did not find the scan classification")
+	}
+
+	var gotFailure *ScanFailure
+	if !errors.As(err, &gotFailure) {
+		t.Fatal("errors.As did not find ScanFailure")
+	}
+	if gotFailure.Code != platformErr.code {
+		t.Fatalf("ScanFailure.Code = %q, want %q", gotFailure.Code, platformErr.code)
+	}
+
+	var gotPlatformErr *platformScanError
+	if !errors.As(err, &gotPlatformErr) {
+		t.Fatal("errors.As did not find the original platform error")
+	}
+	if gotPlatformErr != platformErr {
+		t.Fatalf("errors.As returned platform error %p, want %p", gotPlatformErr, platformErr)
+	}
+
+	want := "NetworkManager request on wlan0: wireless device unavailable: scan rejected"
+	if got := err.Error(); got != want {
+		t.Fatalf("ScanFailure.Error() = %q, want %q", got, want)
+	}
+}

--- a/wifi/iwd/iwd.go
+++ b/wifi/iwd/iwd.go
@@ -11,8 +11,10 @@ import (
 	"github.com/shazow/wifitui/wifi"
 )
 
-const connectionTimeout = 30 * time.Second
+const scanCompletionTimeout = 30 * time.Second
 const propertyChangeTimeout = 5 * time.Second
+
+const dbusPropertiesIface = "org.freedesktop.DBus.Properties"
 
 // IWD constants
 const (
@@ -193,10 +195,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 
 	var scanErr error
 	if scan != wifi.ScanNever {
-		scanErr = conn.Object(iwdDest, station).Call(iwdStationIface+".Scan", 0).Store()
-		if scanErr != nil {
-			scanErr = newScanFailure(scanErr)
-		}
+		scanErr = scanAndWait(conn, station)
 	}
 
 	// GetOrderedNetworks returns a(on): array of (object_path, signal_strength_in_centidBm)
@@ -327,13 +326,102 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		connections = append(connections, c)
 	}
 
-	return wifi.NetworksResult{Networks: connections, ScanError: scanErr}, nil
+	return wifi.NetworksResult{Networks: connections, IsCached: scanErr != nil, ScanError: scanErr}, nil
 }
 
-func newScanFailure(cause error) *wifi.ScanFailure {
+func scanAndWait(conn *dbus.Conn, station dbus.ObjectPath) error {
+	signals := make(chan *dbus.Signal, 10)
+	conn.Signal(signals)
+	defer conn.RemoveSignal(signals)
+
+	matchOptions := []dbus.MatchOption{
+		dbus.WithMatchObjectPath(station),
+		dbus.WithMatchInterface(dbusPropertiesIface),
+		dbus.WithMatchMember("PropertiesChanged"),
+		dbus.WithMatchArg(0, iwdStationIface),
+	}
+	if err := conn.AddMatchSignal(matchOptions...); err != nil {
+		return newScanFailure(wifi.ScanStageSetup, fmt.Errorf("subscribe to scan completion: %w", err))
+	}
+	defer conn.RemoveMatchSignal(matchOptions...)
+
+	if err := conn.Object(iwdDest, station).Call(iwdStationIface+".Scan", 0).Err; err != nil {
+		return newScanFailure(wifi.ScanStageRequest, err)
+	}
+
+	return waitForScanCompletion(signals, station, scanCompletionTimeout)
+}
+
+func waitForScanCompletion(signals <-chan *dbus.Signal, station dbus.ObjectPath, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	scanningStarted := false
+	for {
+		select {
+		case signal, ok := <-signals:
+			if !ok {
+				cause := fmt.Errorf("%w: D-Bus signal channel closed", wifi.ErrScanProtocol)
+				return newScanFailure(wifi.ScanStageCompletion, cause)
+			}
+
+			scanning, matched, err := scanStateChange(signal, station)
+			if err != nil {
+				return newScanFailure(wifi.ScanStageCompletion, err)
+			}
+			if !matched {
+				continue
+			}
+			if scanning {
+				scanningStarted = true
+				continue
+			}
+			if scanningStarted {
+				return nil
+			}
+		case <-timer.C:
+			cause := fmt.Errorf("%w after %s waiting for Scanning to complete", wifi.ErrScanTimeout, timeout)
+			return newScanFailure(wifi.ScanStageCompletion, cause)
+		}
+	}
+}
+
+func scanStateChange(signal *dbus.Signal, station dbus.ObjectPath) (scanning, matched bool, err error) {
+	if signal == nil {
+		return false, false, fmt.Errorf("%w: received an empty D-Bus signal", wifi.ErrScanProtocol)
+	}
+	if signal.Name != dbusPropertiesIface+".PropertiesChanged" || signal.Path != station {
+		return false, false, nil
+	}
+	if len(signal.Body) < 2 {
+		return false, false, fmt.Errorf("%w: PropertiesChanged has %d body fields", wifi.ErrScanProtocol, len(signal.Body))
+	}
+	iface, ok := signal.Body[0].(string)
+	if !ok {
+		return false, false, fmt.Errorf("%w: PropertiesChanged interface has type %T", wifi.ErrScanProtocol, signal.Body[0])
+	}
+	if iface != iwdStationIface {
+		return false, false, nil
+	}
+	changed, ok := signal.Body[1].(map[string]dbus.Variant)
+	if !ok {
+		return false, false, fmt.Errorf("%w: PropertiesChanged values have type %T", wifi.ErrScanProtocol, signal.Body[1])
+	}
+	value, ok := changed["Scanning"]
+	if !ok {
+		return false, false, nil
+	}
+	scanning, ok = value.Value().(bool)
+	if !ok {
+		return false, false, fmt.Errorf("%w: Scanning has type %T", wifi.ErrScanProtocol, value.Value())
+	}
+	return scanning, true, nil
+}
+
+func newScanFailure(stage wifi.ScanStage, cause error) *wifi.ScanFailure {
 	return &wifi.ScanFailure{
 		Backend: "iwd",
-		Stage:   wifi.ScanStageRequest,
+		Stage:   stage,
 		Code:    dbusErrorName(cause),
 		Cause:   cause,
 	}

--- a/wifi/iwd/iwd.go
+++ b/wifi/iwd/iwd.go
@@ -326,7 +326,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		connections = append(connections, c)
 	}
 
-	return wifi.NetworksResult{Networks: connections, IsCached: scanErr != nil, ScanError: scanErr}, nil
+	return wifi.NetworksResult{Networks: connections, ScanError: scanErr}, nil
 }
 
 func scanAndWait(conn *dbus.Conn, station dbus.ObjectPath) error {

--- a/wifi/iwd/iwd.go
+++ b/wifi/iwd/iwd.go
@@ -3,6 +3,7 @@
 package iwd
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -190,9 +191,12 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		return wifi.NetworksResult{}, err
 	}
 
+	var scanErr error
 	if scan != wifi.ScanNever {
-		// Best effort scan
-		_ = conn.Object(iwdDest, station).Call(iwdStationIface+".Scan", 0)
+		scanErr = conn.Object(iwdDest, station).Call(iwdStationIface+".Scan", 0).Store()
+		if scanErr != nil {
+			scanErr = newScanFailure(scanErr)
+		}
 	}
 
 	// GetOrderedNetworks returns a(on): array of (object_path, signal_strength_in_centidBm)
@@ -323,7 +327,28 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		connections = append(connections, c)
 	}
 
-	return wifi.NetworksResult{Networks: connections}, nil
+	return wifi.NetworksResult{Networks: connections, ScanError: scanErr}, nil
+}
+
+func newScanFailure(cause error) *wifi.ScanFailure {
+	return &wifi.ScanFailure{
+		Backend: "iwd",
+		Stage:   wifi.ScanStageRequest,
+		Code:    dbusErrorName(cause),
+		Cause:   cause,
+	}
+}
+
+func dbusErrorName(err error) string {
+	var value dbus.Error
+	if errors.As(err, &value) {
+		return value.Name
+	}
+	var pointer *dbus.Error
+	if errors.As(err, &pointer) && pointer != nil {
+		return pointer.Name
+	}
+	return ""
 }
 
 func (b *Backend) ActivateNetwork(ssid string) error {

--- a/wifi/iwd/iwd_test.go
+++ b/wifi/iwd/iwd_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package iwd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func TestDBusErrorNameThroughWrapping(t *testing.T) {
+	rawErr := dbus.Error{Name: "net.connman.iwd.Error.Busy", Body: []any{"busy"}}
+	err := fmt.Errorf("request scan: %w", rawErr)
+
+	if got := dbusErrorName(err); got != rawErr.Name {
+		t.Fatalf("dbusErrorName() = %q, want %q", got, rawErr.Name)
+	}
+}
+
+func TestNewScanFailurePreservesDBusError(t *testing.T) {
+	rawErr := dbus.Error{Name: "net.connman.iwd.Error.Busy", Body: []any{"busy"}}
+	err := newScanFailure(rawErr)
+
+	if err.Backend != "iwd" || err.Stage != "request" || err.Code != rawErr.Name {
+		t.Fatalf("newScanFailure() = %#v", err)
+	}
+	var gotDBusError dbus.Error
+	if !errors.As(err, &gotDBusError) {
+		t.Fatalf("newScanFailure() did not retain D-Bus error: %v", err)
+	}
+}

--- a/wifi/iwd/iwd_test.go
+++ b/wifi/iwd/iwd_test.go
@@ -6,9 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/shazow/wifitui/wifi"
 )
+
+const testStationPath dbus.ObjectPath = "/net/connman/iwd/0/1"
 
 func TestDBusErrorNameThroughWrapping(t *testing.T) {
 	rawErr := dbus.Error{Name: "net.connman.iwd.Error.Busy", Body: []any{"busy"}}
@@ -21,13 +25,67 @@ func TestDBusErrorNameThroughWrapping(t *testing.T) {
 
 func TestNewScanFailurePreservesDBusError(t *testing.T) {
 	rawErr := dbus.Error{Name: "net.connman.iwd.Error.Busy", Body: []any{"busy"}}
-	err := newScanFailure(rawErr)
+	err := newScanFailure(wifi.ScanStageRequest, rawErr)
 
-	if err.Backend != "iwd" || err.Stage != "request" || err.Code != rawErr.Name {
+	if err.Backend != "iwd" || err.Stage != wifi.ScanStageRequest || err.Code != rawErr.Name {
 		t.Fatalf("newScanFailure() = %#v", err)
 	}
 	var gotDBusError dbus.Error
 	if !errors.As(err, &gotDBusError) {
 		t.Fatalf("newScanFailure() did not retain D-Bus error: %v", err)
+	}
+}
+
+func TestWaitForScanCompletion(t *testing.T) {
+	signals := make(chan *dbus.Signal, 4)
+	signals <- scanningSignal(false)
+	signals <- &dbus.Signal{
+		Name: dbusPropertiesIface + ".PropertiesChanged",
+		Path: testStationPath,
+		Body: []any{iwdStationIface, map[string]dbus.Variant{"State": dbus.MakeVariant("connected")}},
+	}
+	signals <- scanningSignal(true)
+	signals <- scanningSignal(false)
+
+	if err := waitForScanCompletion(signals, testStationPath, time.Second); err != nil {
+		t.Fatalf("waitForScanCompletion() = %v", err)
+	}
+}
+
+func TestWaitForScanCompletionTimesOut(t *testing.T) {
+	err := waitForScanCompletion(make(chan *dbus.Signal), testStationPath, 0)
+
+	if !errors.Is(err, wifi.ErrScanTimeout) {
+		t.Fatalf("waitForScanCompletion() = %v, want ErrScanTimeout", err)
+	}
+	var failure *wifi.ScanFailure
+	if !errors.As(err, &failure) || failure.Stage != wifi.ScanStageCompletion {
+		t.Fatalf("waitForScanCompletion() = %#v, want completion-stage ScanFailure", err)
+	}
+}
+
+func TestWaitForScanCompletionRejectsMalformedScanning(t *testing.T) {
+	signals := make(chan *dbus.Signal, 1)
+	signals <- &dbus.Signal{
+		Name: dbusPropertiesIface + ".PropertiesChanged",
+		Path: testStationPath,
+		Body: []any{iwdStationIface, map[string]dbus.Variant{"Scanning": dbus.MakeVariant("yes")}},
+	}
+
+	err := waitForScanCompletion(signals, testStationPath, time.Second)
+	if !errors.Is(err, wifi.ErrScanProtocol) {
+		t.Fatalf("waitForScanCompletion() = %v, want ErrScanProtocol", err)
+	}
+	var failure *wifi.ScanFailure
+	if !errors.As(err, &failure) || failure.Stage != wifi.ScanStageCompletion {
+		t.Fatalf("waitForScanCompletion() = %#v, want completion-stage ScanFailure", err)
+	}
+}
+
+func scanningSignal(scanning bool) *dbus.Signal {
+	return &dbus.Signal{
+		Name: dbusPropertiesIface + ".PropertiesChanged",
+		Path: testStationPath,
+		Body: []any{iwdStationIface, map[string]dbus.Variant{"Scanning": dbus.MakeVariant(scanning)}},
 	}
 }

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -45,11 +45,18 @@ type Backend struct {
 	scanFunc func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error
 	// scanPermissionFunc is overridden by tests to avoid a real D-Bus call.
 	scanPermissionFunc func() (string, error)
-	scanInterval       time.Duration
-	lastScan           time.Time
-	scanError          error
-	scanMu             sync.Mutex
-	scanDone           chan struct{}
+	// testHookScanWait is overridden by tests to observe scan coordination.
+	testHookScanWait func()
+	scanInterval     time.Duration
+	lastScanAttempt  time.Time
+	scanMu           sync.Mutex
+	scanInFlight     *scanOperation
+}
+
+type scanOperation struct {
+	key  string
+	done chan struct{}
+	err  error
 }
 
 type networkKey struct {
@@ -373,7 +380,7 @@ func (b *Backend) scanHiddenSSID(device gonetworkmanager.DeviceWireless, ssid st
 	if ssid == "" {
 		return nil
 	}
-	return b.scanAndWaitWithOptions(device, hiddenSSIDScanOptions(ssid))
+	return b.scanWithOptions(device, true, "ssid:"+ssid, hiddenSSIDScanOptions(ssid))
 }
 
 // WatchNetworkChanges returns a channel that receives a value when NetworkManager
@@ -487,47 +494,59 @@ func (b *Backend) scanNow(device gonetworkmanager.DeviceWireless) error {
 }
 
 func (b *Backend) scan(device gonetworkmanager.DeviceWireless, force bool) error {
+	return b.scanWithOptions(device, force, "", nil)
+}
+
+// scanWithOptions serializes scan requests so a LastScan update from an older
+// request cannot satisfy a later request with different options. Requests with
+// the same key share the in-flight result; requests with different keys wait
+// and then establish their own LastScan baseline in scanAndWaitWithOptions.
+func (b *Backend) scanWithOptions(device gonetworkmanager.DeviceWireless, force bool, key string, options map[string]dbus.Variant) error {
 	interval := scanInterval
 	if b.scanInterval > 0 {
 		interval = b.scanInterval
 	}
 
-	var done chan struct{}
-	runScan := false
-
-	b.scanMu.Lock()
-	if force || b.lastScan.IsZero() || time.Since(b.lastScan) >= interval {
-		if b.scanDone != nil {
-			done = b.scanDone
-		} else {
-			done = make(chan struct{})
-			b.scanDone = done
-			runScan = true
-		}
-	} else {
-		scanErr := b.scanError
-		b.scanMu.Unlock()
-		return scanErr
-	}
-	b.scanMu.Unlock()
-
-	if runScan {
-		err := b.scanAndWait(device)
+	for {
 		b.scanMu.Lock()
-		b.lastScan = time.Now()
-		b.scanError = err
-		close(done)
-		b.scanDone = nil
-		scanErr := b.scanError
-		b.scanMu.Unlock()
-		return scanErr
-	} else if done != nil {
-		<-done
-	}
+		if current := b.scanInFlight; current != nil {
+			sameRequest := current.key == key
+			b.scanMu.Unlock()
+			if b.testHookScanWait != nil {
+				b.testHookScanWait()
+			}
+			<-current.done
+			if sameRequest {
+				return current.err
+			}
+			continue
+		}
 
-	b.scanMu.Lock()
-	defer b.scanMu.Unlock()
-	return b.scanError
+		// Only ordinary automatic scans use the retry interval. A skipped call
+		// did not attempt or join the previous scan, so it must not inherit that
+		// scan's error.
+		if key == "" && !force && !b.lastScanAttempt.IsZero() && time.Since(b.lastScanAttempt) < interval {
+			b.scanMu.Unlock()
+			return nil
+		}
+
+		operation := &scanOperation{
+			key:  key,
+			done: make(chan struct{}),
+		}
+		b.scanInFlight = operation
+		b.scanMu.Unlock()
+
+		operation.err = b.scanAndWaitWithOptions(device, options)
+		b.scanMu.Lock()
+		if key == "" {
+			b.lastScanAttempt = time.Now()
+		}
+		close(operation.done)
+		b.scanInFlight = nil
+		b.scanMu.Unlock()
+		return operation.err
+	}
 }
 
 func securityFromAccessPoint(flags, wpaFlags, rsnFlags uint32) (wifi.SecurityType, bool) {
@@ -898,7 +917,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 	b.networkKeysBySSID = newNetworkKeysBySSID
 
 	wifi.SortNetworks(conns)
-	return wifi.NetworksResult{Networks: conns, ScanError: scanErr}, nil
+	return wifi.NetworksResult{Networks: conns, IsCached: scanErr != nil, ScanError: scanErr}, nil
 }
 
 func (b *Backend) getConnection(ssid string) (gonetworkmanager.Connection, error) {

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -42,7 +42,7 @@ type Backend struct {
 	scanFunc     func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error
 	scanInterval time.Duration
 	lastScan     time.Time
-	scanCached   bool
+	scanError    error
 	scanMu       sync.Mutex
 	scanDone     chan struct{}
 }
@@ -357,15 +357,15 @@ func isNetworkChangeSignal(sig *dbus.Signal, devicePath dbus.ObjectPath) bool {
 	}
 }
 
-func (b *Backend) scanIfStale(device gonetworkmanager.DeviceWireless) bool {
+func (b *Backend) scanIfStale(device gonetworkmanager.DeviceWireless) error {
 	return b.scan(device, false)
 }
 
-func (b *Backend) scanNow(device gonetworkmanager.DeviceWireless) bool {
+func (b *Backend) scanNow(device gonetworkmanager.DeviceWireless) error {
 	return b.scan(device, true)
 }
 
-func (b *Backend) scan(device gonetworkmanager.DeviceWireless, force bool) bool {
+func (b *Backend) scan(device gonetworkmanager.DeviceWireless, force bool) error {
 	interval := scanInterval
 	if b.scanInterval > 0 {
 		interval = b.scanInterval
@@ -384,9 +384,9 @@ func (b *Backend) scan(device gonetworkmanager.DeviceWireless, force bool) bool 
 			runScan = true
 		}
 	} else {
-		cached := b.scanCached
+		scanErr := b.scanError
 		b.scanMu.Unlock()
-		return cached
+		return scanErr
 	}
 	b.scanMu.Unlock()
 
@@ -394,19 +394,19 @@ func (b *Backend) scan(device gonetworkmanager.DeviceWireless, force bool) bool 
 		err := b.scanAndWait(device)
 		b.scanMu.Lock()
 		b.lastScan = time.Now()
-		b.scanCached = err != nil
+		b.scanError = err
 		close(done)
 		b.scanDone = nil
-		cached := b.scanCached
+		scanErr := b.scanError
 		b.scanMu.Unlock()
-		return cached
+		return scanErr
 	} else if done != nil {
 		<-done
 	}
 
 	b.scanMu.Lock()
 	defer b.scanMu.Unlock()
-	return b.scanCached
+	return b.scanError
 }
 
 func securityFromAccessPoint(flags, wpaFlags, rsnFlags uint32) (wifi.SecurityType, bool) {
@@ -599,12 +599,12 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		return wifi.NetworksResult{}, err
 	}
 
-	isCached := false
+	var scanErr error
 	switch scan {
 	case wifi.ScanAuto:
-		isCached = b.scanIfStale(wirelessDevice)
+		scanErr = b.scanIfStale(wirelessDevice)
 	case wifi.ScanForce:
-		isCached = b.scanNow(wirelessDevice)
+		scanErr = b.scanNow(wirelessDevice)
 	}
 
 	knownConnections, err := b.Settings.ListConnections()
@@ -777,7 +777,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 	b.networkKeysBySSID = newNetworkKeysBySSID
 
 	wifi.SortNetworks(conns)
-	return wifi.NetworksResult{Networks: conns, IsCached: isCached}, nil
+	return wifi.NetworksResult{Networks: conns, ScanError: scanErr}, nil
 }
 
 func (b *Backend) getConnection(ssid string) (gonetworkmanager.Connection, error) {

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -917,7 +917,7 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 	b.networkKeysBySSID = newNetworkKeysBySSID
 
 	wifi.SortNetworks(conns)
-	return wifi.NetworksResult{Networks: conns, IsCached: scanErr != nil, ScanError: scanErr}, nil
+	return wifi.NetworksResult{Networks: conns, ScanError: scanErr}, nil
 }
 
 func (b *Backend) getConnection(ssid string) (gonetworkmanager.Connection, error) {

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -221,6 +221,10 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 				cause := fmt.Errorf("%w: D-Bus signal channel closed", wifi.ErrScanProtocol)
 				return newScanFailure(device, wifi.ScanStageCompletion, cause)
 			}
+			if sig == nil {
+				cause := fmt.Errorf("%w: received an empty D-Bus signal", wifi.ErrScanProtocol)
+				return newScanFailure(device, wifi.ScanStageCompletion, cause)
+			}
 			// Signal body for PropertiesChanged:
 			// interface_name (string)
 			// changed_properties (map[string]dbus.Variant)
@@ -244,6 +248,9 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 			if !ok {
 				cause := fmt.Errorf("%w: LastScan has type %T", wifi.ErrScanProtocol, variant.Value())
 				return newScanFailure(device, wifi.ScanStageCompletion, cause)
+			}
+			if value < 0 {
+				continue
 			}
 			var nextScan time.Duration
 			if value > 0 {
@@ -362,11 +369,11 @@ func hiddenSSIDScanOptions(ssid string) map[string]dbus.Variant {
 	}
 }
 
-func (b *Backend) scanHiddenSSID(device gonetworkmanager.DeviceWireless, ssid string) {
+func (b *Backend) scanHiddenSSID(device gonetworkmanager.DeviceWireless, ssid string) error {
 	if ssid == "" {
-		return
+		return nil
 	}
-	_ = b.scanAndWaitWithOptions(device, hiddenSSIDScanOptions(ssid))
+	return b.scanAndWaitWithOptions(device, hiddenSSIDScanOptions(ssid))
 }
 
 // WatchNetworkChanges returns a channel that receives a value when NetworkManager
@@ -1119,8 +1126,9 @@ func (b *Backend) JoinNetwork(ssid string, password string, security wifi.Securi
 		return err
 	}
 	deviceInterface, _ := wirelessDevice.GetPropertyInterface()
+	var hiddenScanErr error
 	if isHidden {
-		b.scanHiddenSSID(wirelessDevice, ssid)
+		hiddenScanErr = b.scanHiddenSSID(wirelessDevice, ssid)
 	}
 
 	connection := map[string]map[string]interface{}{
@@ -1185,10 +1193,16 @@ func (b *Backend) JoinNetwork(ssid string, password string, security wifi.Securi
 		}
 	}
 	if err != nil {
+		if hiddenScanErr != nil {
+			return fmt.Errorf("failed to activate hidden network after targeted scan failure: %w; scan failure: %w", err, hiddenScanErr)
+		}
 		return err
 	}
 
 	if err := waitForActiveConnection(activeConn); err != nil {
+		if hiddenScanErr != nil {
+			return fmt.Errorf("hidden network activation failed after targeted scan failure: %w; scan failure: %w", err, hiddenScanErr)
+		}
 		return err
 	}
 

--- a/wifi/networkmanager/networkmanager.go
+++ b/wifi/networkmanager/networkmanager.go
@@ -4,6 +4,7 @@ package networkmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/user"
 	"strings"
@@ -21,6 +22,8 @@ const (
 	pollingInterval   = time.Second
 	scanTimeout       = 30 * time.Second
 	scanInterval      = 30 * time.Second
+	diagnosticTimeout = 2 * time.Second
+	nmScanPermission  = "org.freedesktop.NetworkManager.wifi.scan"
 )
 
 const (
@@ -39,12 +42,14 @@ type Backend struct {
 	accessPoints      map[networkKey]gonetworkmanager.AccessPoint
 	networkKeysBySSID map[string][]networkKey
 
-	scanFunc     func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error
-	scanInterval time.Duration
-	lastScan     time.Time
-	scanError    error
-	scanMu       sync.Mutex
-	scanDone     chan struct{}
+	scanFunc func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error
+	// scanPermissionFunc is overridden by tests to avoid a real D-Bus call.
+	scanPermissionFunc func() (string, error)
+	scanInterval       time.Duration
+	lastScan           time.Time
+	scanError          error
+	scanMu             sync.Mutex
+	scanDone           chan struct{}
 }
 
 type networkKey struct {
@@ -103,10 +108,26 @@ func isUnavailableDBusError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if name := dbusErrorName(err); name != "" {
+		return name == "org.freedesktop.DBus.Error.ServiceUnknown" ||
+			name == "org.freedesktop.DBus.Error.NameHasNoOwner"
+	}
 	msg := err.Error()
 	return strings.Contains(msg, "org.freedesktop.DBus.Error.ServiceUnknown") ||
 		strings.Contains(msg, "org.freedesktop.DBus.Error.NameHasNoOwner") ||
 		strings.Contains(msg, "The name is not activatable")
+}
+
+func dbusErrorName(err error) string {
+	var value dbus.Error
+	if errors.As(err, &value) {
+		return value.Name
+	}
+	var pointer *dbus.Error
+	if errors.As(err, &pointer) && pointer != nil {
+		return pointer.Name
+	}
+	return ""
 }
 
 func (b *Backend) getWirelessDevice() (gonetworkmanager.DeviceWireless, error) {
@@ -150,7 +171,10 @@ func (b *Backend) scanAndWait(device gonetworkmanager.DeviceWireless) error {
 
 func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless, options map[string]dbus.Variant) error {
 	if b.scanFunc != nil {
-		return b.scanFunc(device, options)
+		if err := b.scanFunc(device, options); err != nil {
+			return b.scanRequestFailure(device, err)
+		}
+		return nil
 	}
 
 	var baseline time.Duration
@@ -160,7 +184,7 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 
 	conn, err := dbus.SystemBus()
 	if err != nil {
-		return fmt.Errorf("failed to connect to dbus: %w", err)
+		return newScanFailure(device, wifi.ScanStageSetup, fmt.Errorf("connect to system D-Bus: %w", err))
 	}
 
 	path := device.GetPath()
@@ -169,7 +193,7 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 	// We need to add the match rule to receiving signals matching this rule.
 	call := conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
 	if call.Err != nil {
-		return fmt.Errorf("failed to add match rule: %w", call.Err)
+		return newScanFailure(device, wifi.ScanStageSetup, fmt.Errorf("subscribe to scan completion: %w", call.Err))
 	}
 	defer conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, rule)
 
@@ -183,7 +207,7 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 	// Alternatively we can try to autodetect intervals that are too frequent by seeing how often scanTimeout is getting triggered, but this is not ideal.
 	err = b.requestScan(device, options)
 	if err != nil {
-		return err
+		return b.scanRequestFailure(device, err)
 	}
 
 	// Wait for the signal
@@ -192,7 +216,11 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 
 	for {
 		select {
-		case sig := <-c:
+		case sig, ok := <-c:
+			if !ok {
+				cause := fmt.Errorf("%w: D-Bus signal channel closed", wifi.ErrScanProtocol)
+				return newScanFailure(device, wifi.ScanStageCompletion, cause)
+			}
 			// Signal body for PropertiesChanged:
 			// interface_name (string)
 			// changed_properties (map[string]dbus.Variant)
@@ -214,7 +242,8 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 			}
 			value, ok := variant.Value().(int64)
 			if !ok {
-				return nil
+				cause := fmt.Errorf("%w: LastScan has type %T", wifi.ErrScanProtocol, variant.Value())
+				return newScanFailure(device, wifi.ScanStageCompletion, cause)
 			}
 			var nextScan time.Duration
 			if value > 0 {
@@ -224,9 +253,94 @@ func (b *Backend) scanAndWaitWithOptions(device gonetworkmanager.DeviceWireless,
 				return nil
 			}
 		case <-timer.C:
-			return fmt.Errorf("scan timed out")
+			cause := fmt.Errorf("%w after %s waiting for LastScan to change", wifi.ErrScanTimeout, scanTimeout)
+			return newScanFailure(device, wifi.ScanStageCompletion, cause)
 		}
 	}
+}
+
+func newScanFailure(device gonetworkmanager.DeviceWireless, stage wifi.ScanStage, cause error) *wifi.ScanFailure {
+	deviceInterface, _ := device.GetPropertyInterface()
+	return &wifi.ScanFailure{
+		Backend: "NetworkManager",
+		Stage:   stage,
+		Device:  deviceInterface,
+		Code:    dbusErrorName(cause),
+		Cause:   cause,
+	}
+}
+
+func (b *Backend) scanRequestFailure(device gonetworkmanager.DeviceWireless, cause error) error {
+	deviceInterface, _ := device.GetPropertyInterface()
+	if isUnavailableDBusError(cause) {
+		cause = fmt.Errorf("%w: %w", wifi.ErrNotAvailable, cause)
+		return &wifi.ScanFailure{
+			Backend: "NetworkManager",
+			Stage:   wifi.ScanStageRequest,
+			Device:  deviceInterface,
+			Code:    dbusErrorName(cause),
+			Cause:   cause,
+		}
+	}
+
+	managed, managedErr := device.GetPropertyManaged()
+	state, stateErr := device.GetPropertyState()
+
+	if managedErr == nil && !managed {
+		cause = fmt.Errorf("%w (%s is unmanaged): %w", wifi.ErrScanDeviceUnavailable, deviceInterface, cause)
+	} else if stateErr == nil && (state == gonetworkmanager.NmDeviceStateUnmanaged || state == gonetworkmanager.NmDeviceStateUnavailable) {
+		cause = fmt.Errorf("%w (%s is %s): %w", wifi.ErrScanDeviceUnavailable, deviceInterface, scanDeviceStateName(state), cause)
+	} else if name := dbusErrorName(cause); name != "" {
+		permission, permissionErr := b.getScanPermission()
+		switch {
+		case permissionErr == nil && permission == "no":
+			cause = fmt.Errorf("%w: %w", wifi.ErrScanPermissionDenied, cause)
+		case permissionErr == nil && permission == "auth":
+			cause = fmt.Errorf("%w: %w", wifi.ErrScanAuthRequired, cause)
+		case strings.HasSuffix(name, ".AccessDenied") || strings.HasSuffix(name, ".PermissionDenied"):
+			cause = fmt.Errorf("%w: %w", wifi.ErrScanPermissionDenied, cause)
+		}
+	}
+
+	return &wifi.ScanFailure{
+		Backend: "NetworkManager",
+		Stage:   wifi.ScanStageRequest,
+		Device:  deviceInterface,
+		Code:    dbusErrorName(cause),
+		Cause:   cause,
+	}
+}
+
+func scanDeviceStateName(state gonetworkmanager.NmDeviceState) string {
+	switch state {
+	case gonetworkmanager.NmDeviceStateUnmanaged:
+		return "unmanaged"
+	case gonetworkmanager.NmDeviceStateUnavailable:
+		return "unavailable"
+	default:
+		return state.String()
+	}
+}
+
+func (b *Backend) getScanPermission() (string, error) {
+	if b.scanPermissionFunc != nil {
+		return b.scanPermissionFunc()
+	}
+
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return "", err
+	}
+	var permissions map[string]string
+	ctx, cancel := context.WithTimeout(context.Background(), diagnosticTimeout)
+	defer cancel()
+	err = conn.Object(gonetworkmanager.NetworkManagerInterface, gonetworkmanager.NetworkManagerObjectPath).
+		CallWithContext(ctx, gonetworkmanager.NetworkManagerGetPermissions, 0).
+		Store(&permissions)
+	if err != nil {
+		return "", err
+	}
+	return permissions[nmScanPermission], nil
 }
 
 func (b *Backend) requestScan(device gonetworkmanager.DeviceWireless, options map[string]dbus.Variant) error {

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -318,11 +318,81 @@ func TestListNetworks_ReturnsCachedListWhenScanFails(t *testing.T) {
 	if connections[0].SSID != "Cafe" {
 		t.Fatalf("ListNetworks(ScanAuto) returned SSID %q, want Cafe", connections[0].SSID)
 	}
-	if result.ScanError == nil || result.ScanError.Error() != "scan not allowed" {
-		t.Fatalf("ListNetworks(ScanAuto) returned scan error %v, want scan not allowed", result.ScanError)
+	if result.ScanError == nil {
+		t.Fatal("ListNetworks(ScanAuto) did not return the non-fatal scan error")
+	}
+	var scanFailure *wifi.ScanFailure
+	if !errors.As(result.ScanError, &scanFailure) {
+		t.Fatalf("ListNetworks(ScanAuto) returned scan error %T, want *wifi.ScanFailure", result.ScanError)
+	}
+	if scanFailure.Backend != "NetworkManager" || scanFailure.Stage != wifi.ScanStageRequest || scanFailure.Device != "wlan0" {
+		t.Fatalf("ListNetworks(ScanAuto) returned scan failure %#v", scanFailure)
+	}
+	if got, want := result.ScanError.Error(), "NetworkManager request on wlan0: scan not allowed"; got != want {
+		t.Fatalf("ListNetworks(ScanAuto) scan error = %q, want %q", got, want)
 	}
 	if b.lastScan.IsZero() {
 		t.Fatal("ListNetworks(ScanAuto) did not record lastScan after a scan failure")
+	}
+}
+
+func TestListNetworks_ClassifiesUnavailableDeviceScanFailure(t *testing.T) {
+	device := &mockDeviceWireless{
+		managed: true,
+		state:   gonetworkmanager.NmDeviceStateUnavailable,
+		accessPoints: []gonetworkmanager.AccessPoint{
+			newMockAccessPoint("Cafe", "00:00:00:00:00:01", 67),
+		},
+	}
+	b := newTestBackend(device, nil)
+	// Simulate a device that became unavailable after it was selected and cached.
+	b.Device = device
+	rawErr := dbus.Error{
+		Name: "org.freedesktop.NetworkManager.Device.NotAllowed",
+		Body: []any{"Scanning not allowed while unavailable"},
+	}
+	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
+		return rawErr
+	}
+
+	result, err := b.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks(ScanForce) returned fatal error: %v", err)
+	}
+	if !errors.Is(result.ScanError, wifi.ErrScanDeviceUnavailable) {
+		t.Fatalf("scan error %v does not classify the unavailable device", result.ScanError)
+	}
+	var scanFailure *wifi.ScanFailure
+	if !errors.As(result.ScanError, &scanFailure) {
+		t.Fatalf("scan error %T does not retain ScanFailure", result.ScanError)
+	}
+	if scanFailure.Code != rawErr.Name {
+		t.Fatalf("ScanFailure.Code = %q, want %q", scanFailure.Code, rawErr.Name)
+	}
+	var gotDBusError dbus.Error
+	if !errors.As(result.ScanError, &gotDBusError) {
+		t.Fatalf("scan error %v does not retain the D-Bus error", result.ScanError)
+	}
+}
+
+func TestListNetworks_ClassifiesDeniedScanPermission(t *testing.T) {
+	device := &mockDeviceWireless{
+		accessPoints: []gonetworkmanager.AccessPoint{
+			newMockAccessPoint("Cafe", "00:00:00:00:00:01", 67),
+		},
+	}
+	b := newTestBackend(device, nil)
+	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
+		return dbus.Error{Name: "org.freedesktop.NetworkManager.Device.NotAllowed", Body: []any{"Not authorized"}}
+	}
+	b.scanPermissionFunc = func() (string, error) { return "no", nil }
+
+	result, err := b.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks(ScanForce) returned fatal error: %v", err)
+	}
+	if !errors.Is(result.ScanError, wifi.ErrScanPermissionDenied) {
+		t.Fatalf("scan error %v does not classify the denied permission", result.ScanError)
 	}
 }
 

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -318,8 +318,8 @@ func TestListNetworks_ReturnsCachedListWhenScanFails(t *testing.T) {
 	if connections[0].SSID != "Cafe" {
 		t.Fatalf("ListNetworks(ScanAuto) returned SSID %q, want Cafe", connections[0].SSID)
 	}
-	if !result.IsCached {
-		t.Fatal("ListNetworks(ScanAuto) did not mark cached results after scan failure")
+	if result.ScanError == nil || result.ScanError.Error() != "scan not allowed" {
+		t.Fatalf("ListNetworks(ScanAuto) returned scan error %v, want scan not allowed", result.ScanError)
 	}
 	if b.lastScan.IsZero() {
 		t.Fatal("ListNetworks(ScanAuto) did not record lastScan after a scan failure")
@@ -333,7 +333,7 @@ func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
 		},
 	}
 	b := newTestBackend(device, nil)
-	b.scanCached = true
+	b.scanError = errors.New("previous scan failed")
 	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
 		return nil
 	}
@@ -342,8 +342,8 @@ func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListNetworks(ScanAuto) returned error: %v", err)
 	}
-	if result.IsCached {
-		t.Fatal("ListNetworks(ScanAuto) marked cached results after successful scan")
+	if result.ScanError != nil {
+		t.Fatalf("ListNetworks(ScanAuto) retained scan error after successful scan: %v", result.ScanError)
 	}
 }
 

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -999,6 +999,37 @@ func TestJoinNetwork_HiddenScanFailureDoesNotAbortActivation(t *testing.T) {
 	}
 }
 
+func TestJoinNetwork_HiddenActivationFailureIncludesScanFailure(t *testing.T) {
+	device := &mockDeviceWireless{}
+	activationErr := errors.New("activation rejected")
+
+	b := newTestBackend(device, nil)
+	b.Settings = &mockSettings{}
+	b.NM = &mockNM{
+		getDevicesFunc: func() ([]gonetworkmanager.Device, error) {
+			return []gonetworkmanager.Device{device}, nil
+		},
+		activateConnectionFunc: func(gonetworkmanager.Connection, gonetworkmanager.Device, *dbus.Object) (gonetworkmanager.ActiveConnection, error) {
+			return nil, activationErr
+		},
+	}
+	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
+		return errors.New("targeted scan rejected")
+	}
+
+	err := b.JoinNetwork("HiddenNet", "password", wifi.SecurityWPA, true)
+	if err == nil {
+		t.Fatal("JoinNetwork(hidden) returned nil after activation failure")
+	}
+	if !errors.Is(err, activationErr) {
+		t.Fatalf("JoinNetwork(hidden) error %v does not retain activation error", err)
+	}
+	var scanFailure *wifi.ScanFailure
+	if !errors.As(err, &scanFailure) {
+		t.Fatalf("JoinNetwork(hidden) error %v does not retain targeted scan failure", err)
+	}
+}
+
 func TestIsNetworkChangeSignal(t *testing.T) {
 	devicePath := dbus.ObjectPath("/org/freedesktop/NetworkManager/Devices/1")
 	tests := []struct {
@@ -1109,6 +1140,11 @@ func TestIsUnavailableDBusError(t *testing.T) {
 		{
 			name: "name has no owner",
 			err:  testError("org.freedesktop.DBus.Error.NameHasNoOwner: Could not get owner"),
+			want: true,
+		},
+		{
+			name: "typed dbus error",
+			err:  dbus.Error{Name: "org.freedesktop.DBus.Error.ServiceUnknown", Body: []any{"not running"}},
 			want: true,
 		},
 		{

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -331,8 +331,11 @@ func TestListNetworks_ReturnsCachedListWhenScanFails(t *testing.T) {
 	if got, want := result.ScanError.Error(), "NetworkManager request on wlan0: scan not allowed"; got != want {
 		t.Fatalf("ListNetworks(ScanAuto) scan error = %q, want %q", got, want)
 	}
-	if b.lastScan.IsZero() {
-		t.Fatal("ListNetworks(ScanAuto) did not record lastScan after a scan failure")
+	if !result.IsCached {
+		t.Fatal("ListNetworks(ScanAuto) did not mark fallback networks cached")
+	}
+	if b.lastScanAttempt.IsZero() {
+		t.Fatal("ListNetworks(ScanAuto) did not record lastScanAttempt after a scan failure")
 	}
 }
 
@@ -403,17 +406,32 @@ func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
 		},
 	}
 	b := newTestBackend(device, nil)
-	b.scanError = errors.New("previous scan failed")
+	var scanCalls int
 	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
+		scanCalls++
+		if scanCalls == 1 {
+			return errors.New("previous scan failed")
+		}
 		return nil
 	}
 
-	result, err := b.ListNetworks(wifi.ScanAuto)
+	first, err := b.ListNetworks(wifi.ScanForce)
 	if err != nil {
-		t.Fatalf("ListNetworks(ScanAuto) returned error: %v", err)
+		t.Fatalf("first ListNetworks(ScanForce) returned error: %v", err)
+	}
+	if first.ScanError == nil || !first.IsCached {
+		t.Fatalf("first ListNetworks(ScanForce) = %#v, want cached scan failure", first)
+	}
+
+	result, err := b.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("second ListNetworks(ScanForce) returned error: %v", err)
 	}
 	if result.ScanError != nil {
-		t.Fatalf("ListNetworks(ScanAuto) retained scan error after successful scan: %v", result.ScanError)
+		t.Fatalf("second ListNetworks(ScanForce) retained scan error after successful scan: %v", result.ScanError)
+	}
+	if result.IsCached {
+		t.Fatal("second ListNetworks(ScanForce) marked successful results cached")
 	}
 }
 
@@ -424,7 +442,7 @@ func TestListNetworks_SkipsScanWhenLastScanFresh(t *testing.T) {
 		},
 	}
 	b := newTestBackend(device, nil)
-	b.lastScan = time.Now().Add(-10 * time.Second)
+	b.lastScanAttempt = time.Now().Add(-10 * time.Second)
 	b.scanInterval = 30 * time.Second
 	scanCalled := false
 	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
@@ -452,7 +470,7 @@ func TestListNetworks_ForceScanWhenLastScanFresh(t *testing.T) {
 		},
 	}
 	b := newTestBackend(device, nil)
-	b.lastScan = time.Now().Add(-10 * time.Second)
+	b.lastScanAttempt = time.Now().Add(-10 * time.Second)
 	b.scanInterval = 30 * time.Second
 	scanCalled := false
 	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
@@ -492,8 +510,8 @@ func TestListNetworks_RequestsScanWhenLastScanUnset(t *testing.T) {
 	if !scanCalled {
 		t.Fatal("ListNetworks(ScanAuto) skipped scan even though LastScan was unset")
 	}
-	if b.lastScan.IsZero() {
-		t.Fatal("ListNetworks(ScanAuto) did not record lastScan after requesting a scan")
+	if b.lastScanAttempt.IsZero() {
+		t.Fatal("ListNetworks(ScanAuto) did not record lastScanAttempt after requesting a scan")
 	}
 }
 
@@ -502,19 +520,23 @@ func TestScanIfStale_CoalescesConcurrentScans(t *testing.T) {
 	b := newTestBackend(device, nil)
 
 	var scanCalls atomic.Int32
-	enteredScan := make(chan struct{}, 2)
+	enteredScan := make(chan struct{}, 1)
 	releaseScan := make(chan struct{})
+	waiting := make(chan struct{}, 1)
+	scanFailure := errors.New("scan failed")
 	b.scanFunc = func(gonetworkmanager.DeviceWireless, map[string]dbus.Variant) error {
 		scanCalls.Add(1)
 		enteredScan <- struct{}{}
 		<-releaseScan
-		return nil
+		return scanFailure
 	}
+	b.testHookScanWait = func() { waiting <- struct{}{} }
 
 	var wg sync.WaitGroup
+	errs := make(chan error, 2)
 	scan := func() {
 		defer wg.Done()
-		b.scanIfStale(device)
+		errs <- b.scanIfStale(device)
 	}
 
 	wg.Add(1)
@@ -523,19 +545,20 @@ func TestScanIfStale_CoalescesConcurrentScans(t *testing.T) {
 
 	wg.Add(1)
 	go scan()
-
-	select {
-	case <-enteredScan:
-	case <-time.After(20 * time.Millisecond):
-	}
+	<-waiting
 	close(releaseScan)
 	wg.Wait()
 	if got := scanCalls.Load(); got != 1 {
 		t.Fatalf("scanIfStale made %d scan attempts, want 1", got)
 	}
+	for range 2 {
+		if err := <-errs; !errors.Is(err, scanFailure) {
+			t.Fatalf("coalesced scan error = %v, want %v", err, scanFailure)
+		}
+	}
 }
 
-func TestListNetworks_DefersRetryAfterScanFailure(t *testing.T) {
+func TestListNetworks_AutonomousResultsDoNotRepeatScanFailure(t *testing.T) {
 	device := &mockDeviceWireless{
 		accessPoints: []gonetworkmanager.AccessPoint{
 			newMockAccessPoint("Deferred", "00:00:00:00:00:05", 64),
@@ -550,15 +573,89 @@ func TestListNetworks_DefersRetryAfterScanFailure(t *testing.T) {
 		return errors.New("scan not allowed")
 	}
 
-	for range 2 {
-		_, err := b.ListNetworks(wifi.ScanAuto)
-		if err != nil {
-			t.Fatalf("ListNetworks(ScanAuto) returned error: %v", err)
-		}
+	first, err := b.ListNetworks(wifi.ScanAuto)
+	if err != nil {
+		t.Fatalf("first ListNetworks(ScanAuto) returned error: %v", err)
+	}
+	if first.ScanError == nil {
+		t.Fatal("first ListNetworks(ScanAuto) did not return scan failure")
+	}
+
+	// NetworkManager may refresh its access points autonomously while the
+	// client's retry backoff is still active.
+	device.accessPoints = []gonetworkmanager.AccessPoint{
+		newMockAccessPoint("Autonomous", "00:00:00:00:00:06", 72),
+	}
+	second, err := b.ListNetworks(wifi.ScanAuto)
+	if err != nil {
+		t.Fatalf("second ListNetworks(ScanAuto) returned error: %v", err)
+	}
+	if second.ScanError != nil {
+		t.Fatalf("backoff-only ListNetworks(ScanAuto) repeated stale scan failure: %v", second.ScanError)
+	}
+	if len(second.Networks) != 1 || second.Networks[0].SSID != "Autonomous" {
+		t.Fatalf("second ListNetworks(ScanAuto) returned %#v, want autonomous results", second.Networks)
 	}
 
 	if got := scanCalls.Load(); got != 1 {
 		t.Fatalf("ListNetworks(ScanAuto) made %d scan attempts, want 1", got)
+	}
+}
+
+func TestScanHiddenSSID_WaitsForDifferentInFlightScan(t *testing.T) {
+	device := &mockDeviceWireless{}
+	b := newTestBackend(device, nil)
+
+	type scanCall struct {
+		options map[string]dbus.Variant
+		release chan struct{}
+	}
+	calls := make(chan scanCall, 2)
+	waiting := make(chan struct{}, 1)
+	b.scanFunc = func(_ gonetworkmanager.DeviceWireless, options map[string]dbus.Variant) error {
+		call := scanCall{options: options, release: make(chan struct{})}
+		calls <- call
+		<-call.release
+		return nil
+	}
+	b.testHookScanWait = func() { waiting <- struct{}{} }
+
+	normalDone := make(chan error, 1)
+	go func() { normalDone <- b.scanNow(device) }()
+	normal := <-calls
+	if len(normal.options) != 0 {
+		t.Fatalf("normal scan options = %#v, want none", normal.options)
+	}
+
+	hiddenDone := make(chan error, 1)
+	go func() { hiddenDone <- b.scanHiddenSSID(device, "HiddenNet") }()
+	<-waiting
+	select {
+	case call := <-calls:
+		close(call.release)
+		t.Fatal("targeted scan started before the in-flight normal scan completed")
+	default:
+	}
+
+	close(normal.release)
+	if err := <-normalDone; err != nil {
+		t.Fatalf("normal scan returned error: %v", err)
+	}
+
+	targeted := <-calls
+	variant, ok := targeted.options["ssids"]
+	if !ok {
+		close(targeted.release)
+		t.Fatal("targeted scan did not include ssids option")
+	}
+	ssids, ok := variant.Value().([][]byte)
+	if !ok || len(ssids) != 1 || string(ssids[0]) != "HiddenNet" {
+		close(targeted.release)
+		t.Fatalf("targeted scan ssids = %#v, want HiddenNet", variant.Value())
+	}
+	close(targeted.release)
+	if err := <-hiddenDone; err != nil {
+		t.Fatalf("targeted scan returned error: %v", err)
 	}
 }
 

--- a/wifi/networkmanager/networkmanager_test.go
+++ b/wifi/networkmanager/networkmanager_test.go
@@ -331,9 +331,6 @@ func TestListNetworks_ReturnsCachedListWhenScanFails(t *testing.T) {
 	if got, want := result.ScanError.Error(), "NetworkManager request on wlan0: scan not allowed"; got != want {
 		t.Fatalf("ListNetworks(ScanAuto) scan error = %q, want %q", got, want)
 	}
-	if !result.IsCached {
-		t.Fatal("ListNetworks(ScanAuto) did not mark fallback networks cached")
-	}
 	if b.lastScanAttempt.IsZero() {
 		t.Fatal("ListNetworks(ScanAuto) did not record lastScanAttempt after a scan failure")
 	}
@@ -399,7 +396,7 @@ func TestListNetworks_ClassifiesDeniedScanPermission(t *testing.T) {
 	}
 }
 
-func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
+func TestListNetworks_ClearsScanErrorWhenScanSucceeds(t *testing.T) {
 	device := &mockDeviceWireless{
 		accessPoints: []gonetworkmanager.AccessPoint{
 			newMockAccessPoint("Cafe", "00:00:00:00:00:01", 67),
@@ -419,8 +416,8 @@ func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first ListNetworks(ScanForce) returned error: %v", err)
 	}
-	if first.ScanError == nil || !first.IsCached {
-		t.Fatalf("first ListNetworks(ScanForce) = %#v, want cached scan failure", first)
+	if first.ScanError == nil {
+		t.Fatalf("first ListNetworks(ScanForce) = %#v, want scan failure", first)
 	}
 
 	result, err := b.ListNetworks(wifi.ScanForce)
@@ -429,9 +426,6 @@ func TestListNetworks_ClearsCachedWhenScanSucceeds(t *testing.T) {
 	}
 	if result.ScanError != nil {
 		t.Fatalf("second ListNetworks(ScanForce) retained scan error after successful scan: %v", result.ScanError)
-	}
-	if result.IsCached {
-		t.Fatal("second ListNetworks(ScanForce) marked successful results cached")
 	}
 }
 


### PR DESCRIPTION
## Summary

Improve Wi-Fi scan reliability and diagnostics across all backends, with real CoreWLAN scanning on macOS.

Instead of silently returning stale results or showing a generic warning, scan failures now retain their underlying cause and expose a useful diagnostic while still returning available fallback networks.

## What changed

### Shared scan diagnostics

- Added structured `ScanFailure` errors with backend, device, stage, and underlying-cause context.
- Added classifications for unavailable devices, permissions, authorization, timeouts, and malformed responses.
- Added `NetworksResult.ScanError` as the authoritative non-fatal scan-failure signal.
- Preserved wrapped errors for `errors.Is` and `errors.As`.
- Sent CLI scan diagnostics to stderr so normal and JSON stdout remain valid.
- Preserved both scan and connection failures when they occur together.

### NetworkManager

- Classifies scan request and completion failures.
- Coordinates concurrent scan requests.
- Coalesces equivalent requests while serializing scans with different options.
- Prevents old scan failures from leaking into later backoff-only calls.
- Handles targeted hidden-network scans through the same coordinator.

### iwd

- Subscribes to scan-state changes before requesting a scan.
- Waits for the documented `Scanning=true` to `Scanning=false` transition.
- Reports request, timeout, and malformed completion failures accurately.

### macOS

- Replaced `system_profiler` scanning with a native CoreWLAN Objective-C bridge.
- Honors `ScanNever`, `ScanAuto`, and `ScanForce`.
- Retains deep-copied visible-network snapshots for scan-failure fallback.
- Conservatively merges visible, preferred, and currently associated networks.
- Preserves separate security variants without assigning SSID-only metadata to a potentially unsafe variant.
- Provides an explicit unsupported diagnostic when built without cgo.

## Build and release support

- Portable builds use `CGO_ENABLED=0` and prefer static linking.
- Added `make build-darwin` for cgo-enabled CoreWLAN builds.
- Nix disables cgo on Linux and enables it on Darwin.
- GoReleaser now separates portable Linux/FreeBSD targets from Darwin cgo targets.
- Tagged releases run on macOS so official Darwin artifacts can link CoreWLAN.
- Added macOS CI coverage for:
  - Native Intel cgo tests and framework linkage
  - Apple Silicon cross-builds
  - Full GoReleaser snapshots
  - Native Darwin Nix builds

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Linux Nix package build
- All-system flake evaluation
- GoReleaser configuration and portable target builds
- GitHub Actions workflow linting
- Darwin amd64/arm64 fallback builds
- Darwin cgo source-selection checks
- Objective-C syntax checking against the flake’s Apple SDK

Live CoreWLAN behavior and Location Services handling should additionally be smoke-tested using released artifacts on Intel and Apple Silicon Macs.