### PR TITLE
fix(darwin): fall back when CoreWLAN lacks permission

### DIFF
--- a/wifi/darwin/darwin_logic.go
+++ b/wifi/darwin/darwin_logic.go
@@ -40,6 +40,7 @@ type scannedNetwork struct {
 	security  wifi.SecurityType
 	rssi      int
 	frequency uint
+	isActive  bool
 }
 
 type coreWLANNetwork struct {
@@ -123,8 +124,9 @@ type networkScanner func(device string) ([]scannedNetwork, error)
 type Backend struct {
 	WifiInterface string
 
-	runOutput    outputRunner
-	scanNetworks networkScanner
+	runOutput            outputRunner
+	scanNetworks         networkScanner
+	fallbackScanNetworks networkScanner
 
 	cacheMu     sync.RWMutex
 	lastVisible []wifi.Network
@@ -176,6 +178,20 @@ func (b *Backend) ListNetworks(scan wifi.ScanMode) (wifi.NetworksResult, error) 
 		scanner = scanVisibleNetworks
 	}
 	scanned, err := scanner(b.WifiInterface)
+	if err != nil && errors.Is(err, wifi.ErrScanPermissionDenied) {
+		coreWLANErr := err
+		fallbackScanner := b.fallbackScanNetworks
+		if fallbackScanner == nil {
+			fallbackScanner = scanSystemProfilerNetworks
+		}
+		var fallbackErr error
+		scanned, fallbackErr = fallbackScanner(b.WifiInterface)
+		if fallbackErr != nil {
+			err = errors.Join(coreWLANErr, fmt.Errorf("system_profiler fallback failed: %w", fallbackErr))
+		} else {
+			err = nil
+		}
+	}
 	if err != nil {
 		cause := err
 		stage := wifi.ScanStageRequest
@@ -243,11 +259,13 @@ func visibleNetworks(scanned []scannedNetwork) []wifi.Network {
 		key := darwinNetworkKey{ssid: network.ssid, security: network.security}
 		if existing, ok := networksByKey[key]; ok {
 			existing.AccessPoints = append(existing.AccessPoints, accessPoint)
+			existing.IsActive = existing.IsActive || network.isActive
 			networksByKey[key] = existing
 			continue
 		}
 		networksByKey[key] = wifi.Network{
 			SSID:         network.ssid,
+			IsActive:     network.isActive,
 			IsVisible:    true,
 			AccessPoints: []wifi.AccessPoint{accessPoint},
 			IsSecure:     network.security != wifi.SecurityOpen,
@@ -270,7 +288,7 @@ func mergeNetworks(visible []wifi.Network, knownSSIDs map[string]bool, currentSS
 		// Do not apply that metadata to an arbitrary security variant when the
 		// scan found more than one; doing so could mark an open evil twin known.
 		unambiguous := variantCount[network.SSID] == 1
-		network.IsActive = unambiguous && network.SSID == currentSSID
+		network.IsActive = network.IsActive || (unambiguous && network.SSID == currentSSID)
 		network.IsKnown = unambiguous && knownSSIDs[network.SSID]
 		network.AutoConnect = network.IsKnown
 		key := darwinNetworkKey{ssid: network.SSID, security: network.Security}

--- a/wifi/darwin/darwin_test.go
+++ b/wifi/darwin/darwin_test.go
@@ -78,6 +78,110 @@ func baseCommandResults() map[string]commandResult {
 	}
 }
 
+func TestParseSystemProfilerOutputForFallback(t *testing.T) {
+	output := `Wi-Fi:
+      Interfaces:
+        en0:
+          Status: Connected
+          Current Network Information:
+            MyHomeNetwork:
+              Security: WPA2 Personal
+              Signal / Noise: -55 dBm / -95 dBm
+          Other Local Wi-Fi Networks:
+            OpenCafe:
+              Security: Open
+              Signal / Noise: -75 dBm / -90 dBm
+        awdl0:
+          MAC Address: 00:11:22:33:44:55`
+
+	networks := parseSystemProfilerOutput(output)
+	if len(networks) != 2 {
+		t.Fatalf("parsed %d networks, want 2: %#v", len(networks), networks)
+	}
+	home := networks[0]
+	if home.ssid != "MyHomeNetwork" || !home.isActive || home.rssi != -55 || home.security != wifi.SecurityWPA {
+		t.Fatalf("current network = %#v, want active WPA MyHomeNetwork at -55 dBm", home)
+	}
+	cafe := networks[1]
+	if cafe.ssid != "OpenCafe" || cafe.isActive || cafe.rssi != -75 || cafe.security != wifi.SecurityOpen {
+		t.Fatalf("other network = %#v, want inactive open OpenCafe at -75 dBm", cafe)
+	}
+}
+
+func TestParseSystemProfilerOutputAcceptsSSIDContentAndSecurityVariants(t *testing.T) {
+	output := `Wi-Fi:
+      Interfaces:
+        en0:
+          Other Local Wi-Fi Networks:
+            awdlCafe:
+              Security: Open
+              Signal / Noise: -61 dBm / -90 dBm
+            Cafe: Guest:
+              Security: WPA2 Personal
+              Signal / Noise: -62 dBm / -90 dBm
+            Twin:
+              Security: Open
+              Signal / Noise: -70 dBm / -90 dBm
+            Twin:
+              Security: WPA3 Personal
+              Signal / Noise: -50 dBm / -90 dBm
+            Mystery:
+              Security: Future Quantum
+              Signal / Noise: -80 dBm / -90 dBm
+        awdl0:
+          MAC Address: 00:11:22:33:44:55`
+
+	networks := parseSystemProfilerOutput(output)
+	if len(networks) != 5 {
+		t.Fatalf("parsed %d networks, want all 5 records: %#v", len(networks), networks)
+	}
+	if networks[0].ssid != "awdlCafe" || networks[1].ssid != "Cafe: Guest" {
+		t.Fatalf("SSID content was treated as syntax: %#v", networks)
+	}
+	if networks[2].ssid != "Twin" || networks[2].security != wifi.SecurityOpen ||
+		networks[3].ssid != "Twin" || networks[3].security != wifi.SecurityWPA {
+		t.Fatalf("security variants were collapsed or misclassified: %#v", networks)
+	}
+	if networks[4].security != wifi.SecurityUnknown {
+		t.Fatalf("unknown security = %v, want SecurityUnknown", networks[4].security)
+	}
+}
+
+func TestParseSystemProfilerOutputTreatsSectionLabelsAsSSIDContentAtNetworkIndent(t *testing.T) {
+	output := `Wi-Fi:
+      Interfaces:
+        en0:
+          Other Local Wi-Fi Networks:
+            Current Network Information:
+              Security: Open
+            Other Local Wi-Fi Networks:
+              Security: WPA2 Personal
+            FollowingNetwork:
+              Security: Open
+        awdl0:
+          MAC Address: 00:11:22:33:44:55`
+
+	networks := parseSystemProfilerOutput(output)
+	if len(networks) != 3 {
+		t.Fatalf("parsed %d networks, want section-like SSIDs plus following network: %#v", len(networks), networks)
+	}
+	if networks[0].ssid != "Current Network Information" || networks[0].isActive ||
+		networks[1].ssid != "Other Local Wi-Fi Networks" || networks[1].isActive ||
+		networks[2].ssid != "FollowingNetwork" || networks[2].isActive {
+		t.Fatalf("section-like SSIDs changed parser state: %#v", networks)
+	}
+}
+
+func TestVisibleNetworksPreservesActiveAcrossDuplicateVariant(t *testing.T) {
+	networks := visibleNetworks([]scannedNetwork{
+		{ssid: "Home", security: wifi.SecurityWPA, rssi: -70},
+		{ssid: "Home", security: wifi.SecurityWPA, rssi: -50, isActive: true},
+	})
+	if len(networks) != 1 || !networks[0].IsActive || len(networks[0].AccessPoints) != 2 {
+		t.Fatalf("duplicate active variant = %#v, want one active network with two access points", networks)
+	}
+}
+
 func TestListNetworksScanNeverSkipsScan(t *testing.T) {
 	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
 	backend := &Backend{
@@ -176,6 +280,68 @@ func TestListNetworksScanFailureReturnsVisibleCurrentNetwork(t *testing.T) {
 	}
 	if len(result.Networks) != 2 || result.Networks[0].SSID != "Guest" || !result.Networks[0].IsVisible {
 		t.Fatalf("fallback networks = %#v, want visible current Guest first", result.Networks)
+	}
+}
+
+func TestListNetworksPermissionFailureFallsBackToSystemProfiler(t *testing.T) {
+	results := baseCommandResults()
+	results["networksetup -getairportnetwork en0"] = commandResult{err: errors.New("association unavailable")}
+	runner := &fakeOutputRunner{t: t, results: results}
+	fallbackCalls := 0
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, fmt.Errorf("SSIDs unavailable: %w", wifi.ErrScanPermissionDenied)
+		},
+		fallbackScanNetworks: func(device string) ([]scannedNetwork, error) {
+			fallbackCalls++
+			if device != "en0" {
+				t.Fatalf("fallback device = %q, want en0", device)
+			}
+			return []scannedNetwork{{
+				ssid: "Guest", security: wifi.SecurityWPA, rssi: -55, isActive: true,
+			}}, nil
+		},
+	}
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks returned an error: %v", err)
+	}
+	if result.ScanError != nil {
+		t.Fatalf("successful system_profiler fallback returned a scan error: %v", result.ScanError)
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("fallback scan calls = %d, want 1", fallbackCalls)
+	}
+	guest, ok := networkBySSID(result.Networks, "Guest")
+	if !ok || !guest.IsVisible || !guest.IsActive || guest.Strength() != 90 {
+		t.Fatalf("fallback Guest = %#v, %t; want visible active network at 90%%", guest, ok)
+	}
+}
+
+func TestListNetworksPermissionFallbackFailurePreservesBothErrors(t *testing.T) {
+	coreErr := fmt.Errorf("SSIDs unavailable: %w", wifi.ErrScanPermissionDenied)
+	fallbackErr := errors.New("system_profiler failed")
+	runner := &fakeOutputRunner{t: t, results: baseCommandResults()}
+	backend := &Backend{
+		WifiInterface: "en0",
+		runOutput:     runner.run,
+		scanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, coreErr
+		},
+		fallbackScanNetworks: func(string) ([]scannedNetwork, error) {
+			return nil, fallbackErr
+		},
+	}
+
+	result, err := backend.ListNetworks(wifi.ScanForce)
+	if err != nil {
+		t.Fatalf("ListNetworks returned a fatal error: %v", err)
+	}
+	if !errors.Is(result.ScanError, wifi.ErrScanPermissionDenied) || !errors.Is(result.ScanError, fallbackErr) {
+		t.Fatalf("ScanError = %v, want both CoreWLAN permission and system_profiler errors", result.ScanError)
 	}
 }
 

--- a/wifi/darwin/system_profiler.go
+++ b/wifi/darwin/system_profiler.go
@@ -1,0 +1,109 @@
+package darwin
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/shazow/wifitui/wifi"
+)
+
+// scanSystemProfilerNetworks is a compatibility fallback for macOS processes
+// that cannot read SSIDs through CoreWLAN because Location Services has not
+// authorized the calling binary. system_profiler is slower, but its Apple-
+// managed process can still provide the same visible-network snapshot used by
+// wifitui before the native CoreWLAN scanner was introduced.
+func scanSystemProfilerNetworks(_ string) ([]scannedNetwork, error) {
+	out, err := runWithOutput(exec.Command("system_profiler", "SPAirPortDataType"))
+	if err != nil {
+		return nil, fmt.Errorf("system_profiler Wi-Fi scan failed: %w", err)
+	}
+	return parseSystemProfilerOutput(string(out)), nil
+}
+
+// parseSystemProfilerOutput extracts current and nearby networks from the
+// human-readable SPAirPortDataType report. It intentionally remains isolated
+// to the permission fallback; CoreWLAN is still authoritative when available.
+func parseSystemProfilerOutput(output string) []scannedNetwork {
+	var networks []scannedNetwork
+	scanner := bufio.NewScanner(strings.NewReader(output))
+
+	inCurrentNetwork := false
+	inOtherNetworks := false
+	var currentNetwork *scannedNetwork
+
+	signalRE := regexp.MustCompile(`Signal / Noise:\s*(-?\d+)\s*dBm`)
+	securityRE := regexp.MustCompile(`Security:\s*(.+)`)
+
+	store := func(network *scannedNetwork) {
+		if network == nil || network.ssid == "" {
+			return
+		}
+		networks = append(networks, *network)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		leadingSpaces := len(line) - len(strings.TrimLeft(line, " "))
+
+		// Interface records are eight spaces deep, while network records are
+		// twelve. Match structure rather than interface/SSID text so names such
+		// as "awdlCafe" remain valid networks.
+		if (inCurrentNetwork || inOtherNetworks) && leadingSpaces == 8 && strings.HasSuffix(trimmed, ":") {
+			store(currentNetwork)
+			return networks
+		}
+		switch {
+		case leadingSpaces == 10 && trimmed == "Current Network Information:":
+			inCurrentNetwork = true
+			inOtherNetworks = false
+			continue
+		case leadingSpaces == 10 && trimmed == "Other Local Wi-Fi Networks:":
+			inCurrentNetwork = false
+			inOtherNetworks = true
+			continue
+		}
+		if !inCurrentNetwork && !inOtherNetworks {
+			continue
+		}
+
+		if leadingSpaces == 12 && strings.HasSuffix(trimmed, ":") {
+			store(currentNetwork)
+			currentNetwork = &scannedNetwork{
+				ssid:     strings.TrimSuffix(trimmed, ":"),
+				security: wifi.SecurityUnknown,
+				isActive: inCurrentNetwork,
+			}
+			continue
+		}
+
+		if currentNetwork != nil {
+			if matches := signalRE.FindStringSubmatch(line); len(matches) > 1 {
+				currentNetwork.rssi, _ = strconv.Atoi(matches[1])
+			}
+			if matches := securityRE.FindStringSubmatch(line); len(matches) > 1 {
+				currentNetwork.security = parseSystemProfilerSecurity(matches[1])
+			}
+		}
+	}
+	store(currentNetwork)
+	return networks
+}
+
+func parseSystemProfilerSecurity(value string) wifi.SecurityType {
+	value = strings.ToLower(value)
+	switch {
+	case strings.Contains(value, "wpa"):
+		return wifi.SecurityWPA
+	case strings.Contains(value, "wep"):
+		return wifi.SecurityWEP
+	case strings.Contains(value, "open") || strings.TrimSpace(value) == "none":
+		return wifi.SecurityOpen
+	default:
+		return wifi.SecurityUnknown
+	}
+}


### PR DESCRIPTION
## Summary

- keep native CoreWLAN as the primary Darwin scanner
- fall back to `system_profiler SPAirPortDataType` only when CoreWLAN reports Location Services / permission denial
- preserve current-network active state from the profiler fallback when `networksetup -getairportnetwork` is also unavailable
- retain separate SSID/security variants and preserve both CoreWLAN and fallback errors if both paths fail

## Why

On an ad-hoc-signed CLI on macOS 26.5.2, CoreWLAN scanning is denied/redacted because the calling binary has no stable TCC Location Services authorization. The previous `system_profiler` backend still returns visible and current-network information because it runs as an Apple platform binary.

A CoreWLAN-only implementation therefore regresses from one active/visible network to none in the same execution context. A stable signed helper/app with an interactive location authorization flow could make pure CoreWLAN work, but that changes the project's distribution and UX. This patch keeps the fast native path for authorized callers while restoring compatibility for ordinary CLI builds.

## Live verification

Apple Silicon, macOS 26.5.2, ad-hoc/linker-signed binary. SSIDs were redacted from the report:

```text
json_valid=true
network_count=3
visible_count=2
active_count=1
known_count=1
stderr_empty=true
```

The number of nearby networks varied during repeated scans, but active-state recovery and valid JSON output were stable.

## Tests

```text
go test -race -count=1 ./...
go vet ./...
```

Added coverage for:

- permission-denied CoreWLAN → successful profiler fallback
- both fallback errors remaining discoverable with `errors.Is`
- current/other network classification, RSSI, and security parsing
- SSIDs beginning with `awdl`, containing `: `, or matching profiler section labels
- separate open/WPA variants sharing an SSID
- unknown security remaining `SecurityUnknown`
- active-state propagation across duplicate same-security records

Follow-up to #190.
