### PR TITLE
feat: prefill network list with cached snapshot before first scan

### DIFF
--- a/internal/tui/component.go
+++ b/internal/tui/component.go
@@ -64,7 +64,8 @@ type (
 		networks []wifi.Network
 		scanErr  error
 	}
-	secretsLoadedMsg struct {
+	cachedNetworksMsg []wifi.Network // Cached snapshot prefilled before the first scan
+	secretsLoadedMsg  struct {
 		item   networkItem
 		secret string
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -332,6 +332,21 @@ func (m *ListModel) Update(msg tea.Msg) (Component, tea.Cmd) {
 		m.list.SetItems(items)
 		m.updateListSize()
 		return m, nil
+	case cachedNetworksMsg:
+		// Prefill with the backend's cached snapshot while the initial scan is
+		// deferred. Cancelled when something already populated the list (e.g. a
+		// network-change refresh landed first); the scan result replaces it
+		// shortly after anyway.
+		if len(m.list.Items()) == 0 {
+			m.refreshColumns(msg)
+			items := make([]list.Item, len(msg))
+			for i, c := range msg {
+				items[i] = networkItem{Network: c}
+			}
+			m.list.SetItems(items)
+			m.updateListSize()
+		}
+		return m, nil
 	case scanFinishedMsg:
 		m.refreshColumns(msg.networks)
 		items := make([]list.Item, len(msg.networks))

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -28,6 +28,12 @@ type model struct {
 
 	networkChangeCancel   context.CancelFunc
 	networkRefreshPending bool
+
+	// prefillPending is true while the startup cached-list fetch is in flight.
+	// Scans are deferred until it lands so the two ListNetworks calls never
+	// run concurrently (the backends mutate shared caches).
+	prefillPending  bool
+	pendingScanMode wifi.ScanMode
 }
 
 // NetworkManager can send several AP/device signals for one scan update.
@@ -51,10 +57,11 @@ func NewModel(b wifi.Backend) (*model, error) {
 	listModel := NewListModelWithWindow(window)
 
 	m := model{
-		stack:     NewComponentStack(listModel),
-		spinner:   s,
-		backend:   b,
-		listModel: listModel,
+		stack:           NewComponentStack(listModel),
+		spinner:         s,
+		backend:         b,
+		listModel:       listModel,
+		pendingScanMode: wifi.ScanAuto,
 	}
 	return &m, nil
 }
@@ -83,7 +90,28 @@ func (m *model) Init() tea.Cmd {
 
 	cmds = append(cmds, startNetworkChangeWatcher(m.backend))
 	cmds = append(cmds, m.spinner.Tick)
+	// Prefill with the cached network list before the scan runs. Scans are
+	// deferred until this lands (see the scanMsg handler), so the two fetches
+	// never overlap.
+	m.prefillPending = true
+	cmds = append(cmds, fetchCachedNetworks(m.backend))
 	return tea.Batch(cmds...)
+}
+
+// fetchCachedNetworks prefills the list with the backend's cached network
+// snapshot, the same fast scan-free path used by `wifitui list`. It is best
+// effort: on failure it returns an empty result so the deferred scan still runs
+// and surfaces the real backend error.
+func fetchCachedNetworks(b wifi.Backend) tea.Cmd {
+	return func() tea.Msg {
+		result, err := b.ListNetworks(wifi.ScanNever)
+		if err != nil {
+			return cachedNetworksMsg{}
+		}
+		networks := result.Networks
+		wifi.SortNetworks(networks)
+		return cachedNetworksMsg(networks)
+	}
 }
 
 // Update handles all incoming messages and updates the model accordingly
@@ -154,6 +182,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Skip additional scans while we're still loading
 			return m, nil
 		}
+		if m.prefillPending {
+			// The cached-list prefill is still in flight. Defer the scan until
+			// it lands so the two ListNetworks calls never run concurrently.
+			m.pendingScanMode = msg.mode
+			return m, nil
+		}
 		m.statusMessage = "Scanning for networks..."
 		m.loading = true
 		return m, func() tea.Msg {
@@ -168,6 +202,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				scanErr:  result.ScanError,
 			}
 		}
+	case cachedNetworksMsg:
+		// The cached snapshot has landed: cancel the prefill and run the scan
+		// that was deferred while it was in flight. Fall through so the list
+		// model fills from the cached snapshot (it skips itself if a refresh
+		// already populated the list, i.e. the prefill is cancelled).
+		m.prefillPending = false
+		mode := m.pendingScanMode
+		m.pendingScanMode = wifi.ScanAuto
+		cmds = append(cmds, func() tea.Msg { return scanMsg{mode: mode} })
 	case connectMsg:
 		var batch []tea.Cmd = []tea.Cmd{
 			func() tea.Msg {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -12,6 +12,149 @@ import (
 	"github.com/shazow/wifitui/wifi/mock"
 )
 
+func TestTuiModel_CachedNetworksPrefillsEmptyList(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	m, err := NewModel(backend)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+
+	// Set a size for the model, otherwise the list component won't have enough space to render.
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(*model)
+
+	// The cached snapshot arrives before the scan.
+	updatedModel, _ = m.Update(cachedNetworksMsg{
+		{SSID: "CachedNet", IsVisible: true},
+	})
+	m = updatedModel.(*model)
+
+	view := m.View()
+	if !strings.Contains(view, "CachedNet") {
+		t.Errorf("View does not contain prefilled cached network in\n%s", view)
+	}
+	if got := len(m.listModel.list.Items()); got != 1 {
+		t.Fatalf("list has %d items, want 1 prefilled item", got)
+	}
+}
+
+func TestTuiModel_ScanReplacesCachedPrefill(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	m, err := NewModel(backend)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(*model)
+
+	updatedModel, _ = m.Update(cachedNetworksMsg{
+		{SSID: "CachedNet", IsVisible: true},
+	})
+	m = updatedModel.(*model)
+
+	// The scan result replaces the cached snapshot.
+	updatedModel, _ = m.Update(scanFinishedMsg{networks: []wifi.Network{
+		{SSID: "CachedNet", IsVisible: true, AccessPoints: []wifi.AccessPoint{{Strength: 90}}},
+		{SSID: "OtherNet", IsVisible: true},
+	}})
+	m = updatedModel.(*model)
+
+	if got := len(m.listModel.list.Items()); got != 2 {
+		t.Fatalf("list has %d items, want 2 from scan result", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "CachedNet") || !strings.Contains(view, "OtherNet") {
+		t.Errorf("View does not contain scan results in\n%s", view)
+	}
+}
+
+func TestTuiModel_CachedPrefillDoesNotClobberLoadedList(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	m, err := NewModel(backend)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(*model)
+
+	// A refresh lands before the cached prefill result.
+	updatedModel, _ = m.Update(scanFinishedMsg{networks: []wifi.Network{{SSID: "ScannedNet", IsVisible: true}}})
+	m = updatedModel.(*model)
+	updatedModel, _ = m.Update(cachedNetworksMsg{
+		{SSID: "CachedNet", IsVisible: true},
+	})
+	m = updatedModel.(*model)
+
+	if got := len(m.listModel.list.Items()); got != 1 {
+		t.Fatalf("list has %d items, want 1 scan result", got)
+	}
+	view := m.View()
+	if strings.Contains(view, "CachedNet") {
+		t.Errorf("cached prefill clobbered the loaded list in\n%s", view)
+	}
+}
+
+func TestTuiModel_ScanDeferredUntilCachedPrefillLands(t *testing.T) {
+	backend, err := mock.New()
+	if err != nil {
+		t.Fatalf("mock.New() failed: %v", err)
+	}
+	watch := &watchBackend{
+		Backend: backend,
+		networks: []wifi.Network{
+			{SSID: "DeferredNet", IsVisible: true},
+		},
+	}
+	m, err := NewModel(watch)
+	if err != nil {
+		t.Fatalf("NewModel failed: %v", err)
+	}
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = updatedModel.(*model)
+
+	// A scan is requested while the cached prefill is still in flight.
+	m.prefillPending = true
+	updatedModel, cmd := m.Update(scanMsg{mode: wifi.ScanForce})
+	m = updatedModel.(*model)
+	if cmd != nil {
+		t.Fatal("scanMsg during prefill should be deferred, not executed")
+	}
+	if !m.prefillPending {
+		t.Fatal("prefillPending was cleared by the deferred scan")
+	}
+
+	// When the cached snapshot lands, the deferred scan fires with its mode.
+	updatedModel, cmd = m.Update(cachedNetworksMsg{
+		{SSID: "CachedNet", IsVisible: true},
+	})
+	m = updatedModel.(*model)
+	if cmd == nil {
+		t.Fatal("cachedNetworksMsg did not return a command")
+	}
+	if m.prefillPending {
+		t.Fatal("prefillPending was not cleared after the cached snapshot landed")
+	}
+
+	// The deferred scan runs (with its requested mode) and replaces the prefill.
+	m = runTUITestCommand(t, m, cmd)
+	if len(watch.listScans) != 1 || watch.listScans[0] != wifi.ScanForce {
+		t.Fatalf("deferred scan used modes %#v, want only ScanForce", watch.listScans)
+	}
+	view := m.View()
+	if !strings.Contains(view, "DeferredNet") {
+		t.Errorf("View does not contain scan result in\n%s", view)
+	}
+}
+
 func TestTuiModel_ScanFinishedUpdatesList(t *testing.T) {
 	backend, err := mock.New()
 	if err != nil {


### PR DESCRIPTION
The TUI now prefills the list with the backend's cached network snapshot
as soon as it opens, instead of waiting for the first scan to complete.
It reuses the same fast, scan-free path as `wifitui list`:
ListNetworks(wifi.ScanNever) reads the backend's cached access points and
saved profiles with no scan request.

The cached read and the scan run sequentially: scans are deferred until
the cached snapshot lands, so the two ListNetworks calls never run
concurrently and the backends need no extra synchronization. Each fills
the list through its own message state: cachedNetworksMsg renders the
cached snapshot, and scanFinishedMsg replaces it with fresh results as
before. The cached prefill is cancelled when a refresh already populated
the list, and is best effort: on fetch failure the deferred scan still
runs and surfaces the real backend error.
